### PR TITLE
[GOVCMSD9-68] Add Encrypt module and patches for TFA

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "drupal/dropzonejs": "2.3.0",
         "drupal/ds": "3.9.0",
         "drupal/dynamic_entity_reference": "1.11.0",
+        "drupal/encrypt": "3.0",
         "drupal/entity_browser": "2.5",
         "drupal/entity_class_formatter": "1.3",
         "drupal/entity_embed": "1.1",
@@ -129,7 +130,12 @@
             "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
         },
         "enable-patching": true,
-        "patches": {}
+        "patches": {
+            "Create Email one-time-code Validation Plugin & related Setup Plugin - https://www.drupal.org/project/tfa/issues/2930541":
+              "https://www.drupal.org/files/issues/2020-10-26/tfa-2930541-25-do-not-test.patch",
+            "Users' recovery codes exposed to admin users - https://www.drupal.org/project/tfa/issues/3075304":
+              "https://www.drupal.org/files/issues/2020-11-16/tfa-3075304-11.patch"
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Background
The 8.x-1.0-alpha5 is the first version that is compatible with Drupal 9. We need to update TFA module to this version at least.

### To do:

1. Update TFA module to 1.0-alpha5 and required modules.
2. Patch following issue (feature): 

- Avoid users' recovery codes exposed to admin users (Critical feature for GovCMS 9)

- Email one-time-code Validation Plugin & related Setup Plugin (Critical feature for GovCMS 9)

