### PR TITLE
[GOVCMSD9-89] Fix bulk upload bugs for GovCMS Media module

### DIFF
--- a/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php
+++ b/modules/custom/core/govcms_media/src/Form/BulkUploadForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\govcms_media\Form;
 
+use Drupal\Component\Utility\Environment;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -84,7 +85,7 @@ class BulkUploadForm extends FormBase {
     ];
 
     $variables = [
-      '@max_size' => static::bytesToString(file_upload_max_size()),
+      '@max_size' => static::bytesToString(Environment::getUploadMaxSize()),
       '@extensions' => Element::oxford($extensions),
     ];
     $form['dropzone']['#description'] = $this->t('You can upload as many files as you like. Each file can be up to @max_size in size. The following file extensions are accepted: @extensions', $variables);

--- a/modules/custom/core/govcms_media/src/MediaHelper.php
+++ b/modules/custom/core/govcms_media/src/MediaHelper.php
@@ -3,6 +3,7 @@
 namespace Drupal\govcms_media;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\FileInterface;
 use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\govcms_media\Exception\IndeterminateBundleException;
@@ -192,7 +193,7 @@ class MediaHelper {
     $item = static::getSourceField($entity)->first();
 
     $dir = $item->getUploadLocation();
-    $is_ready = file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
+    $is_ready = \Drupal::service('file_system')->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
     if ($is_ready) {
       return $dir;


### PR DESCRIPTION
Following functions have been deprecated from D9:

- [file_upload_max_size()](https://api.drupal.org/api/drupal/core%21includes%21file.inc/function/file_upload_max_size/8.9.x)
- [file_prepare_directory()](https://api.drupal.org/api/drupal/core%21includes%21file.inc/function/file_prepare_directory/8.9.x)

Replace above functions with following D9 version:

- [Environment::getUploadMaxSize()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21Environment.php/function/Environment%3A%3AgetUploadMaxSize/9.2.x)
- [FileSystemInterface::prepareDirectory()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21File%21FileSystemInterface.php/function/FileSystemInterface%3A%3AprepareDirectory/9.2.x)