### PR TITLE
[GOVCMSD9-69] remove 'Welcome to' from site name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: docker network prune -f && docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
       - run:
           name: Install site
-          command: docker-compose exec -T test drush si -y govcms --site-name="Welcome to GovCMS" install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL
+          command: docker-compose exec -T test drush si -y govcms --site-name="GovCMS" install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL
       - run:
           name: Get site and module version status
           command: |

--- a/tests/behat/features/ui/home.feature
+++ b/tests/behat/features/ui/home.feature
@@ -7,7 +7,7 @@ Feature: Home Page
 
   @api @javascript
   Scenario: View the homepage content
-    And I should see "Welcome to GovCMS"
+    And I should see "GovCMS"
 
   Scenario: Check the homepage meta tag.
     Then the response should contain "<meta name=\"Generator\" content=\"Drupal 9 (http://drupal.org) + GovCMS (http://govcms.gov.au)\" />"


### PR DESCRIPTION
Problem/Motivation
Currently, the site name is set as "Welcome to GovCMS" in .circleci/config.yml and .ahoy.yml

This will lead to a title with "Welcome to Welcome to GovCMS" in testing environments.

Proposed resolution
Rename the default site name to "GovCMS" in the above files and make sure the tests can be passed.