### PR TITLE
[GOVCMSD9-40] Reference fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,15 @@ volumes:
 services:
 
   cli: # cli container, will be used for executing composer and any local commands (drush, drupal, etc.)
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/govcms7:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/govcms8:edge-9.x
     << : *default-volumes # loads the defined volumes from the top
     environment:
       << : *default-environment
 
   test:
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/test:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/test:edge-9.x
     << : *default-volumes
     depends_on:
       - cli
@@ -30,7 +32,8 @@ services:
       << : *default-environment
 
   nginx:
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/nginx-drupal:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/nginx-drupal:edge-9.x
     << : *default-volumes
     environment:
       << : *default-environment
@@ -39,20 +42,23 @@ services:
       - default
 
   php:
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/php:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/php:edge-9.x
     << : *default-volumes
     environment:
       << : *default-environment
 
   mariadb:
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/mariadb-drupal:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/mariadb-drupal:edge-9.x
     ports:
       - "3306" # Find port on host with `docker-compose port mariadb 3306`
     environment:
       << : *default-environment
 
   solr:
-    image: ${DOCKERHUB_NAMESPACE:-govcmslagoon}/solr:${DOCKERHUB_LABEL:-latest}
+    # To be changed when govcms9lagoon images become available.
+    image: govcms8lagoon/solr:edge-9.x
     ports:
       - "8983" # Find port on host with `docker-compose port solr 8983`
     environment:


### PR DESCRIPTION
Follow-up to GOVCMSD9-40 - switches references to use Drupal 9 images.
Not configurable at this time due to the lack of availability on Docker Hub.