### PR TITLE
[GOVCMSD9-101] Created deprecated module for module_filter

### DIFF
--- a/modules/deprecated/module_filter/module_filter.info.yml
+++ b/modules/deprecated/module_filter/module_filter.info.yml
@@ -1,0 +1,6 @@
+name: Module Filter
+type: module
+description: Filter the modules list.
+package: GovCMS8 [deprecated]
+core: 8.x
+core_version_requirement: ^8 || ^9


### PR DESCRIPTION
Created an empty module for `module_filter` module. It has been deprecated in Govcms9.