### PR TITLE
[GOVCMSD9-274] Update drupal/search_api from 1.18 to 1.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "drupal/rest_menu_items": "3.0.2",
         "drupal/robotstxt": "1.4",
         "drupal/scheduled_transitions": "2.0.0",
-        "drupal/search_api": "1.18.0",
+        "drupal/search_api": "1.19.0",
         "drupal/search_api_attachments": "1.0-beta16",
         "drupal/search_api_solr": "4.1.7",
         "drupal/seckit": "2.0.0",


### PR DESCRIPTION
## search_api 8.x-1.19
### Release notes
This is release 1.19 of the Search API module, containing several bug fixes and new features.

Complete list of changes since release 1.18:
#3182306 by drunken monkey: Improved output from the "rebuild tracker" batch job.
#3111383 by liquidcms, drunken monkey: Fixed problems with exposed, grouped Views date filters.
#3127099 by Grimreaper, drunken monkey: Added option to expose searched fields in Views fulltext filter.
#2944371 by Upchuk, jasonschweb, drunken monkey: Fixed random sort for DB backend.
#3194016 by mkalkbrenner, borisson_: Fixed PHP 8 compatibility.
#3181827 by brunodbo, drunken monkey: Fixed wrong @var type doc in ContentEntityTrackingManager.
#3179045 by sebish, joelpittet, drunken monkey: Fixed parameter type hint in ContentEntityTrackingManager.
#3178417 by SivaprasadC, drunken monkey: Fixed two typos in the Database backend plugin class.
#3174778 by drunken monkey: Fixed some encoding errors.
#3178941 by drunken monkey, cspitzlay, MegaChriz, ooziedie, bakulahluwalia: Fixed fatal error when saving entities with certain setups.
#3036504 by kfritsche, drunken monkey: Fixed memory issues during indexing via Drush.
#3136277 by drunken monkey, pfrenssen, Berdir, dwinters, calmforce: Fixed issue with modifying condition group via pre-execute event/hook.
#3174657 by drunken monkey: Fixed "keep facets" feature for search views when facet source wasn't saved.
#3181936 by drunken monkey: Fixed tests on Drupal 9.1.x HEAD.