### PR TITLE
[GOVCMSD9-275] Update search_api_solr ( 4.1.7 to 4.1.11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "drupal/scheduled_transitions": "2.0.0",
         "drupal/search_api": "1.18.0",
         "drupal/search_api_attachments": "1.0-beta16",
-        "drupal/search_api_solr": "4.1.7",
+        "drupal/search_api_solr": "4.1.11",
         "drupal/seckit": "2.0.0",
         "drupal/shield": "1.4",
         "drupal/simple_oauth": "5.0.2",


### PR DESCRIPTION
## search_api_solr 4.1.11
### Release notes
Search API Solr 4.1.x is the unified release that supports Drupal 8 and 9 and a wide range of Solr versions.

The big changes in 4.x compared to 3.x:

semantic versioning
compatible to Drupal 8.8, 8.9 and 9.x
We upgraded to solarium 6.0 and therefore require at least PHP 7.2
basic support for older Solr versions between 4.5 and 5.5 via the new search_api_solr_legacy sub-module
jump-start Solr config-sets you could simply copy and deploy on you're Solr sever to create a core or a collection
Like Search API Solr Search 8.x-3.x, it supports upgrade paths from any previous 8.x version including Search API Solr Multilingual 8.x-1.x!