### PR TITLE
[GovCMSD9-327] added login_security.settings.yml

### DIFF
--- a/config/install/login_security.settings.yml
+++ b/config/install/login_security.settings.yml
@@ -1,0 +1,19 @@
+track_time:                   0.1
+user_wrong_count:             5
+host_wrong_count:             0
+host_wrong_count_hard:        0
+activity_threshold:           0
+disable_core_login_error:     1
+notice_attempts_available:    1
+last_login_timestamp:         1
+last_access_timestamp:        0
+user_blocked_email_user:      ''
+login_activity_email_user:    ''
+notice_attempts_message:      'Unrecognised username or password. Have you <a href="/user/password">forgotten your password</a>?'
+host_soft_banned:             'This host is not allowed to log in to @site. Please contact your site administrator.'
+host_hard_banned:             'The IP address @ip is banned at @site, and will not be able to access any of its content from now on. Please contact the site administrator.'
+user_blocked:                 'The user @username has been blocked due to failed login attempts.'
+user_blocked_email_subject: '%site: The user @username has been blocked'
+user_blocked_email_body:      'The user @username (@edit_uri) has been blocked at @site due to the amount of failed login attempts.'
+login_activity_email_subject: 'Security information: Unexpected login activity has been detected at @site.'
+login_activity_email_body:    'The configured threshold of @activity_threshold logins has been reached with a total of @tracking_current_count invalid login attempts. You should review your log information about login attempts at @site.'


### PR DESCRIPTION
Need to bring in the default config for Login Security module. The default config settings are currently in D8 (https://github.com/govCMS/GovCMS/tree/1.x/config/install) but not in D9.

The config for Login Security module has been added. 