### PR TITLE
[GOVCMSD9-369] Update media_entity_file_replace from 8.x-1.0-beta3 to 8.x-1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "drupal/linked_field": "1.3.0",
         "drupal/linkit": "6.0.0-beta2",
         "drupal/login_security": "2.0.0",
-        "drupal/media_entity_file_replace": "1.0-beta3",
+        "drupal/media_entity_file_replace": "1.0",
         "drupal/menu_block": "1.6",
         "drupal/menu_trail_by_path": "1.3",
         "drupal/metatag": "1.14.0",


### PR DESCRIPTION
# media_entity_file_replace 8.x-1.0
## Release notes
There are no changes since the last beta. Check the project page for a list of known issues.