### PR TITLE
[GOVCMSD8-884] Update bigmenu to 2.0.0-rc2 from 2.0.0-rc1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/admin_toolbar": "2.3",
         "drupal/adminimal_admin_toolbar": "1.11.0",
         "drupal/adminimal_theme": "1.4",
-        "drupal/bigmenu": "2.0.0-rc1",
+        "drupal/bigmenu": "2.0.0-rc2",
         "drupal/captcha": "1.1",
         "drupal/chosen": "2.9.0",
         "drupal/components": "2.2",


### PR DESCRIPTION
# bigmenu 2.0.0-rc2
## Release notes
Fixes a bug with non-existent menu_links