### PR TITLE
[GOVCMSD9-379] Update to Drupal from 9.1.9 to 9.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.0.0-beta6",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.1.9",
+        "drupal/core-recommended": "9.2.0",
         "drupal/crop": "2.1",
         "drupal/ctools": "3.6.0",
         "drupal/devel": "4.0.1",


### PR DESCRIPTION
**Release notes**
This is a minor version (feature release) of Drupal 9 and is ready for use on production sites. Learn more about Drupal 9 and the Drupal core release cycle.

This minor release provides new improvements and functionality without breaking backward compatibility (BC) for public APIs. Note that there may be changes in internal APIs and experimental modules that require updates to contributed and custom modules and themes per Drupal core's backwards compatibility and experimental module policies.

Drupal 9.2.x contains new features, and should be the target for new site development. Drupal 9.1.x will continue to have security support until December 2021.

9.0.x will no longer receive security support, so sites on a Drupal 9.0.x version should upgrade to a supported release as soon as possible.

Drupal 8.9.x security coverage ends in November 2021, before Drupal 9.3.0 will be released, so if you are using Drupal 8, you must upgrade to Drupal 9.2 before November to keep your site secure.

https://www.drupal.org/project/drupal/releases/9.2.0