### PR TITLE
[GOVCMSD9-428][SA-CORE-2021-004] Update D9 Core to Drupal 9.2.2 from 9.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.0.0-beta6",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.2.1",
+        "drupal/core-recommended": "9.2.2",
         "drupal/crop": "2.1",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.0.1",


### PR DESCRIPTION
https://www.drupal.org/sa-core-2021-004


Project: 
Drupal core
Date: 
2021-July-21
Security risk: 
Critical 15∕25 AC:Complex/A:User/CI:All/II:All/E:Theoretical/TD:Uncommon
Vulnerability: 
Drupal core - Critical - Third-party libraries
CVE IDs: 
CVE-2021-32610
Description: 
The Drupal project uses the pear Archive_Tar library, which has released a security update that impacts Drupal.

The vulnerability is mitigated by the fact that Drupal core's use of the Archive_Tar library is not vulnerable, as it does not permit symlinks.

Exploitation may be possible if contrib or custom code uses the library to extract tar archives (for example .tar, .tar.gz, .bz2, or .tlz) which come from a potentially untrusted source.

This advisory is not covered by Drupal Steward.