### PR TITLE
Add a patch to resolve fatal error on migration group add page.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -171,6 +171,9 @@
             },
             "drupal/twig_tweak": {
                 "sanitize input": "https://www.drupal.org/files/issues/2021-02-03/twig_tweak-token-xss.patch"
+            },
+            "drupal/migrate_tools": {
+                "3217775 - You have requested a non-existent service entity.query": "https://www.drupal.org/files/issues/2021-07-14/you-have-requested-a-non-existent-service-entity-query-3217775-4.patch"
             }
         }
     },


### PR DESCRIPTION
Steps to Reproduce the issue:

- I've setup Govcms saas 9 project using https://github.com/govCMS/scaffold repository `git clone https://github.com/govCMS/scaffold.git && cd scaffold && ahoy init tga saas 9 && ahoy drush si govcms`
- Govcms Profile version - 2.2.0
- Enable the modules - migrate, migrate_plus, migrate_tools, and migrate_source_csv
- Login as Administrator
- Go to /admin/structure/migrate/add
- Boom! Fatal error

There's an open issue in the migrate tools module to fix this issue https://www.drupal.org/project/migrate_tools/issues/3217775