### PR TITLE
[GOVCMSD8-897] Update core

### DIFF
--- a/composer-lagoon.json
+++ b/composer-lagoon.json
@@ -25,7 +25,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core-recommended": "8.9.17",
+        "drupal/core-recommended": "8.9.18",
         "drush/drush": "^9.0.0",
         "govcms/govcms": "*",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta6",
-        "drupal/core-recommended": "8.9.17",
+        "drupal/core-recommended": "8.9.18",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.7.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
# drupal 8.9.18
Release notes
Maintenance and security release of the Drupal 8 series.

This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

Drupal core - Critical - Third-party library - SA-CORE-2021-005
No other fixes are included.

Which release do I choose? Security coverage information
Sites on 8.9.x should update immediately to this release, but update to Drupal 9 as soon as possible afterward because Drupal 8 is end-of-life in three months.
Versions of Drupal 8 prior to 8.9.x are end-of-life and do not receive security coverage.
Important update information
No changes have been made to the .htaccess, web.config, robots.txt, or default settings.php files in this release, so upgrading custom versions of those files is not necessary if your site is already on the previous release.