### PR TITLE
[GOVCMSD9-429] Remove users ability to "Enable TFA" from the Drupal UI

### DIFF
--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -80,6 +80,17 @@ function govcms_security_form_user_admin_permissions_alter(&$form, FormStateInte
 }
 
 /**
+ * Implement hook_form_FORM_ID_alter()
+ */
+function govcms_security_form_tfa_settings_form_alter(&$form, FormStateInterface $form_state){
+  // Remove site admin's ability to disable TFA from the Drupal UI and change the roles required to set up TFA
+  If (\Drupal::currentUser()->id() != 1) {
+    $form['tfa_enabled']['#access'] = FALSE;
+    $form['tfa_required_roles']['#access'] = FALSE;
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function govcms_security_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
…to enable TFA from the Drupal UI

Update govcms_security.module to remove users ability to enable TFA from the Drupal UI