### PR TITLE
[GOVCMSD8-902] Update Webform from 8.x-5.25 to 8.x-5.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "drupal/update_notifications_disable": "1.0",
         "drupal/username_enumeration_prevention": "1.1",
         "drupal/video_embed_field": "2.0",
-        "drupal/webform": "5.25",
+        "drupal/webform": "5.28",
         "oomphinc/composer-installers-extender": "^1.1",
         "swiftmailer/swiftmailer": "6.2.3",
         "symfony/event-dispatcher": "4.3.11 as 3.4.41",


### PR DESCRIPTION
# Webform - Moderately critical - Cross Site Scripting - SA-CONTRIB-2021-026
https://www.drupal.org/sa-contrib-2021-026

**Project:** 
Webform
**Date:** 
2021-August-25
**Security risk:** 
Moderately critical 12∕25 AC:Basic/A:User/CI:Some/II:Some/E:Theoretical/TD:Uncommon
**Vulnerability:** 
Cross Site Scripting

## Description: 
The Webform module uses the CKEditor, library for WYSIWYG editing. CKEditor has released a security update that impacts Webform.

An attacker that can create or edit content (even without access to CKEditor themselves) may be able to exploit one or more Cross-Site Scripting (XSS) vulnerabilities to target users with access to the WYSIWYG CKEditor, including site admins with privileged access.

For more information, see CKEditor's announcement of the release.

## Solution: 
Install the latest version:

If you use the Webform module module for Drupal 8/9 upgrade to Webform 8.x-5.28 or Webform 6.0.5
If you are using a previous release of the Webform module you can immediately do one of several options.

## Update Drupal
If you are using Composer, run drush webform:libraries:composer > DRUPAL_ROOT/composer.libraries.json and run composer update
If you are using Drush, run drush webform:libraries:update



# webform 8.x-5.28
https://www.drupal.org/project/webform/releases/8.x-5.28

