### PR TITLE
[GOVCMSD8-904] Update Drupal core to 8.9.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "drupal/consumers": "1.11",
         "drupal/contact_storage": "1.0.0",
         "drupal/context": "4.0-beta6",
-        "drupal/core-recommended": "8.9.18",
+        "drupal/core-recommended": "8.9.19",
         "drupal/crop":"2.1",
         "drupal/ctools": "3.7.0",
         "drupal/diff": "1.0",


### PR DESCRIPTION
This PR is also covering for the ticket GOVCMSD8-905, GOVCMSD8-906, GOVCMSD8-907 & GOVCMSD8-908
https://www.drupal.org/sa-core-2021-006
https://www.drupal.org/sa-core-2021-007
https://www.drupal.org/sa-core-2021-008
https://www.drupal.org/sa-core-2021-009
https://www.drupal.org/sa-core-2021-010

Following the solution for those SA 
Install the latest version:

**If you are using Drupal 8.9, update to Drupal 8.9.19.**