### PR TITLE
[GOVCMSD8-921] Update Linkit module from 6.0-beta2 to 6.0-beta3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "drupal/inline_entity_form": "1.0-rc9",
         "drupal/key": "1.14",
         "drupal/linked_field": "1.3.0",
-        "drupal/linkit": "6.0-beta2",
+        "drupal/linkit": "6.0-beta3",
         "drupal/login_security": "2.0",
         "drupal/mailsystem": "4.3",
         "drupal/media_entity_file_replace": "1.0",


### PR DESCRIPTION
# Release notes
Resolves Linkit - Moderately critical - Cross Site Scripting - SA-CONTRIB-2021-042.

https://www.drupal.org/project/linkit/releases/6.0.0-beta3