### PR TITLE
[GOVCMSD9-525] schedule change for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "16:00"
+    time: "06:00"
+    timezone: "Australia/Sydney"
   open-pull-requests-limit: 20
   target-branch: 2.x-develop
   reviewers:


### PR DESCRIPTION
Updating the time and timezone of the Dependabot. 

Ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#scheduletimezone