### PR TITLE
Remove the 'import' button on the config sync page.

### DIFF
--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -92,6 +92,16 @@ function govcms_security_form_tfa_settings_form_alter(&$form, FormStateInterface
 }
 
 /**
+ * Implement hook_form_FORM_ID_alter()
+ */
+function govcms_security_form_config_admin_import_form_alter(&$form, FormStateInterface $form_state) {
+  if (\Drupal::currentUser()->id() != 1) {
+    $form['actions']['submit']['#access'] = FALSE;
+    $form['#submit'] = ['govcms_security_config_sync_submit'];
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function govcms_security_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -174,6 +184,13 @@ function govcms_security_permissions_submit($form, FormStateInterface $form_stat
     }
     $role->save();
   }
+}
+
+/**
+ * Display a message around disabled config synchronization.
+ */
+function govcms_security_config_sync_submit() {
+  \Drupal::messenger()->addError("Configuration sync is blocked via govcms_security module.");
 }
 
 /**


### PR DESCRIPTION
This allows the "synchronize configuration" permission to be reinstated, by removing the "import all" button and functionality.

This allows users to still compare the diff between database and config files on disk, while removing the ability to import disallowed configuration.

## Screenshots
<img width="942" alt="Screen Shot 2022-03-02 at 3 13 27 PM" src="https://user-images.githubusercontent.com/1256274/156281559-f826260f-01f8-4b33-9dc1-850338327aef.png">


*IF* a user manages to submit the form (with button removed) then the form handler will block with the following message
<img width="955" alt="Screen Shot 2022-03-02 at 3 19 35 PM" src="https://user-images.githubusercontent.com/1256274/156282170-74255338-3983-4776-808e-26ab8d427ea9.png">

