### PR TITLE
Update drupal/core-recommended requirement from 9.2.13 to 9.2.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.2.15",
+        "drupal/core-recommended": "9.2.16",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.3",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/config_perms": "2.0",
         "drupal/config_split": "1.5.0",
         "drupal/config_update": "1.7",
-        "drupal/consumers": "1.11",
+        "drupal/consumers": "1.12.0",
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.2.13",
+        "drupal/core-recommended": "9.2.15",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.3",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "drupal/google_analytics": "3.1",
         "drupal/govcms_dlm": "1.4.0",
         "drupal/honeypot": "2.0.2",
-        "drupal/inline_entity_form": "1.0.0-rc9",
+        "drupal/inline_entity_form": "1.0.0-rc10",
         "drupal/key": "1.15.0",
         "drupal/layout_builder_modal": "1.1",
         "drupal/layout_builder_restrictions": "2.12.0",


### PR DESCRIPTION
https://www.drupal.org/project/drupal/releases/9.2.16

This is a security release of the Drupal 9 series.

This release fixes security vulnerabilities. Sites are [urged to update immediately](https://www.drupal.org/docs/updating-drupal/options-for-updating-drupal-core) after reading the notes below and the security announcement:

[Drupal core - Moderately critical - Third-party libraries - SA-CORE-2022-006](https://www.drupal.org/sa-core-2022-006)
No other fixes are included.