### PR TITLE
[GOVCMSD9-667] Update drupal/consumers requirement from 1.11 to 1.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/config_perms": "2.0",
         "drupal/config_split": "1.5.0",
         "drupal/config_update": "1.7",
-        "drupal/consumers": "1.11",
+        "drupal/consumers": "1.12.0",
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",


### PR DESCRIPTION
Reverts govCMS/GovCMS#434