### PR TITLE
[GOVCMSD9-663] Update drupal/chosen requirement from 3.0.1 to 3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/adminimal_theme": "1.6.0",
         "drupal/bigmenu": "2.0.0-rc2",
         "drupal/block_place": "1.0",
-        "drupal/chosen": "3.0.1",
+        "drupal/chosen": "3.0.2",
         "drupal/components": "2.4.0",
         "drupal/config_filter": "2.2.0",
         "drupal/config_ignore": "2.3.0",


### PR DESCRIPTION
Reverts govCMS/GovCMS#433