### PR TITLE
Replace asset-packagist with manual package definitions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,33 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
+            "type": "package",
+            "package": {
+                "name": "harvesthq/chosen",
+                "version": "v1.8.7",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/harvesthq/chosen/releases/download/v1.8.7/chosen_v1.8.7.zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "dropzone/dropzone",
+                "version": "v5.9.3",
+                "type": "drupal-library",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/dropzone/dropzone/releases/download/v5.9.3/dist.zip"
+                }
+            }
         }
     ],
     "require": {
         "php": "^7.4",
-        "bower-asset/chosen": "1.8.7",
+        "harvesthq/chosen": "1.8.7",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/address": "1.10.0",
@@ -113,7 +133,7 @@
         "drupal/username_enumeration_prevention": "1.2.0",
         "drupal/video_embed_field": "2.4",
         "drupal/webform": "6.1.3",
-        "npm-asset/dropzone": "5.9.3",
+        "dropzone/dropzone": "5.9.3",
         "oomphinc/composer-installers-extender": "^2.0",
         "swiftmailer/swiftmailer": "6.3.0",
         "webflo/drupal-finder": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
             "type": "package",
             "package": {
                 "name": "dropzone/dropzone",
-                "version": "v5.9.3",
+                "version": "v5.7.2",
                 "type": "drupal-library",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/dropzone/dropzone/releases/download/v5.9.3/dist.zip"
+                    "url": "https://github.com/dropzone/dropzone/archive/refs/tags/v5.7.2.zip"
                 }
             }
         }
@@ -133,7 +133,7 @@
         "drupal/username_enumeration_prevention": "1.2.0",
         "drupal/video_embed_field": "2.4",
         "drupal/webform": "6.1.3",
-        "dropzone/dropzone": "5.9.3",
+        "dropzone/dropzone": "5.7.2",
         "oomphinc/composer-installers-extender": "^2.0",
         "swiftmailer/swiftmailer": "6.3.0",
         "webflo/drupal-finder": "^1.2"


### PR DESCRIPTION
asset-packagist.org is down with no clear timeframe for recovery. The repository is maintained by maintained by a Kyiv based team called HiQDev.

* https://github.com/hiqdev/asset-packagist/issues/146
* https://ryanszrama.com/blog/04-18-2022/replace-asset-packagist-custom-package-repositories

This PR repoints the libraries to their source releases on respective Github repos.

Thoughts go out to the HiQDev team who likely have far more important things on their minds. 🇺🇦 