### PR TITLE
[GOVCMSD9-756] [SA-CORE-2022-011] Update Core to 9.3.17 from 9.3.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.3.16",
+        "drupal/core-recommended": "9.3.17",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.5",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/contact_storage": "1.1.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.3.14",
+        "drupal/core-recommended": "9.3.16",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.5",


### PR DESCRIPTION
**drupal 9.3.16**
https://www.drupal.org/project/drupal/releases/9.3.16

Release notes
This is a security release of the Drupal 9 series.

This release fixes security vulnerabilities. Sites are [urged to update immediately](https://www.drupal.org/docs/updating-drupal/options-for-updating-drupal-core) after reading the notes below and the security announcements:

[Drupal core - Moderately critical - Third-party libraries - SA-CORE-2022-011](https://www.drupal.org/sa-core-2022-011)
No other fixes are included.

Which release do I choose? Security coverage information
Drupal 9.3.x will receive security coverage [until December 8, 2022 when Drupal 9.5.0 is released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule).
Sites on 9.2.x or earlier should update immediately to [Drupal 9.2.21](https://www.drupal.org/project/drupal/releases/9.2.21) instead of this release (but update to 9.3 or higher soon).
Versions of Drupal 9 prior to 9.2.x are end-of-life and do not receive security coverage.
Versions of Drupal 8 are end-of-life and do not receive security coverage.
Important update information
Drupal 9.3 core now requires guzzlehttp/guzzle 6.5.7 or higher (up from 6.5.6).
No changes have been made to the .htaccess, web.config, robots.txt, or default settings.php files in this release, so updating custom versions of those files is not necessary if your site is already on the previous release.
 
**drupal 9.3.15**
https://www.drupal.org/project/drupal/releases/9.3.15

Release notes
This is a patch (bugfix) release of Drupal 9 and is ready for use on production sites. [Learn more about Drupal 9](https://www.drupal.org/about/9).

Drupal 9.3.x will receive security coverage until December 2022.

If you are upgrading from Drupal 8, read [upgrading a Drupal 8 site to Drupal 9](https://www.drupal.org/docs/updating-drupal/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/upgrading-a-drupal-8-site), [9.0.0 release notes](https://www.drupal.org/project/drupal/releases/9.0.0), and the [9.3.0 release notes](https://www.drupal.org/project/drupal/releases/9.3.0) before upgrading to this release.

Important update information

CKEditor 5 has been updated from 34.0.1 to 34.1.0, which fixes several bugs affecting Drupal core.
Known issues
[Search the issue queue for known issues](https://www.drupal.org/project/issues/search/drupal?project_issue_followers=&status%5B%5D=Open&version%5B%5D=any_9.&version%5B%5D=any_8.&issue_tags_op=%3D).

All changes since 9.3.13
[Issue #3274648 by nod_, Wim Leers: HTMLRestrictions::merge() and ::toGeneralHtmlSupportConfig() fail on allowed attribute values that can be interpreted as integers](https://git.drupalcode.org/project/drupal/commit/fd25d6368e19ee40f669e195f53882b77a664a1a)
[Issue #3276217 by lauriii, Wim Leers: [drupalMedia] add tests to confirm GHS attributes are retained in linked media](https://git.drupalcode.org/project/drupal/commit/818bd6737b7f26c1f5ab13daf20f8446aa163300)
[Issue #3280985 by mherchel, andy-blum: Olivero's code block styling is slightly broken at various viewport widths](https://git.drupalcode.org/project/drupal/commit/6a00c3f8c78f6ef485730c1df1e52b11716a03dd)
[Issue #3274651 by Wim Leers, nod_, alexpott: Impossible to enable <ol type> or <ul type> with GHS: switch to List's successor, DocumentList](https://git.drupalcode.org/project/drupal/commit/97a241b9c2e4843f44d05f2abe000e0c01e48079)
[Issue #3277438 by Wim Leers, bnjmnm, lauriii, xjm, nod_, Reinmar: Update to CKEditor 5 v34.1.0](https://git.drupalcode.org/project/drupal/commit/6a674770b13b4a0ba69e6e91b2604eb1008e4198)
[SA-CORE-2022-010 by mayela, mxr576, xjm, cilefen, greggles, benjifisher, alexpott](https://git.drupalcode.org/project/drupal/commit/ed29aa42a25ee6d68ffcc2a215c6db3745083782)
[Issue #2513524 by andregp, JeroenT, Bill Choy, TR, tstoeckler, dawehner, Wim Leers, xjm: ExtensionDiscovery is unable to find modules that have a comment at the end of the type property in a .info.yml file](https://git.drupalcode.org/project/drupal/commit/3586d9b316cbfeb3363784c6883d77e7b43d8330)
[Issue #3275237 by hooroomoo, lauriii, Wim Leers, nod_: Don't convert, instead use response.entity_type in DrupalImageUploadEditing](https://git.drupalcode.org/project/drupal/commit/f5aced44461d4fac96d010bb1b01e8733aaf37b0)
[Issue #3058409 by guilhermevp, joachim, ravi.shankar, quietone, init90, andregp: TermStorage::loadTree() doesn't document what the return array is keyed by](https://git.drupalcode.org/project/drupal/commit/5a9f90aab04af4f089e80d71b3793448ff50bc0e)
[Issue #3232714 by paulocs, vsujeetkumar, mondrake, longwave, quietone, larowlan: Replace, in tests, mocks that do not configure doubles with their actual objects](https://git.drupalcode.org/project/drupal/commit/e6247d26325dc49e0a2fd0e650111ab0dc3074a0)
[Issue #3268746 by quietone, xjm: Fix missing newlines for 'Drupal.Commenting.DocComment.ShortSingleLine'](https://git.drupalcode.org/project/drupal/commit/7177a7cbe1debef19df189527965a1f9a7bf445b)
[Issue #3280602 by larowlan, DanielVeza, Wim Leers, mstrelan: Exceptions for CKEditor 5 plugin definitions containing wildcard tags when PHP is built with libxml 2.9.14](https://git.drupalcode.org/project/drupal/commit/c858497aa07b5a324e3af376146a5f5f8c99aa47)
[Issue #3259593 by hooroomoo, Dom., Wim Leers, bnjmnm, lauriii: Alignment being available as separate buttons AND in dropdown is confusing](https://git.drupalcode.org/project/drupal/commit/a9a069604caf6de83e2416b31825a487ff590cbb)
[Issue #3250582 by huzooka, Matroskeen, danflanagan8, ravi.shankar, quietone, erik.erskine: ResponsiveImageStyles source plugin must extend DrupalSqlBase](https://git.drupalcode.org/project/drupal/commit/ec8f30ee618084491a33d7fb6f8909221c5aecba)
[Issue #3260920 by tstoeckler: Contact's MessageEntityTest wrongly uses 'edit' access operation on entities instead of 'update'](https://git.drupalcode.org/project/drupal/commit/2925ad48c7cd5be40631fe735090ff12d8272c90)
[Issue #3278394 by Wim Leers, bnjmnm: HTMLRestrictions' diff operation bug: diff(<tag attr="A B">, <tag attr>) should return an empty result](https://git.drupalcode.org/project/drupal/commit/f79131723c317b6f32388f8cb41b1f889c6f7188)
[Issue #2580263 by Berdir, nils.destoop, catch, Cottser, larowlan: Find a way to not run contextual_preprocess() on every template](https://git.drupalcode.org/project/drupal/commit/470f3181019a062e61247d133eb47fe889b2ce0d)
[Issue #3280614 by Spokje: (Not so) Random test failures QuickEditFileTest](https://git.drupalcode.org/project/drupal/commit/ce6cc9b5f8c366d1985d5b9c1f6e163686cb0912)
[Issue #3272336 by danflanagan8: File tests should not rely on Classy](https://git.drupalcode.org/project/drupal/commit/8327c68f32866a564e4d67cd463ad63996134be9)
[Issue #3279502 by webflo: Fix invalid @property annotations](https://git.drupalcode.org/project/drupal/commit/9d8501cb00b2ffb210f18a62a2b964a1125b2b7b)
[Issue #3218562 by bradjones1, yogeshmpawar, Lendude, catch: Fix typo in/rename SearchSimplifyTest](https://git.drupalcode.org/project/drupal/commit/e74dad581981065868d0fae3a99c7046b08a759a)
[Issue #3272543 by danflanagan8, larowlan: History tests should not rely on Classy](https://git.drupalcode.org/project/drupal/commit/977296347428c47fbe898c833f073c8362d4ac29)
[Issue #3279103 by bradjones1: Test cleanup: Remove dead code from JsonApiFunctionalTest](https://git.drupalcode.org/project/drupal/commit/d513429ed27633eae62652c4ad06af9653d1901e)
[Issue #3278314 by acbramley: InlineBlockUsageInterface::getUsage can return FALSE but isn't documented](https://git.drupalcode.org/project/drupal/commit/6ffe8b73c8fbadd41d087827193862ac82a6e01c)
[Issue #3270081 by franck_lorancy, quietone, Cottser: Fix indentation in doc block \Drupal\Core\Render\RendererInterface::render](https://git.drupalcode.org/project/drupal/commit/1d657bd0ce50c0088f932ca6767504f79e87d8ea)
[Issue #2314443 by olli, Lendude, immaculatexavier, dawehner: Changing view name does not update page title in views ui](https://git.drupalcode.org/project/drupal/commit/d3c42ff26fd9113e1e00ddc10def96d00d2d1d6c)
[Issue #2917239 by Lendude, dww, iStryker: Form is built when not using fields](https://git.drupalcode.org/project/drupal/commit/169c75c5673fb1211392d4da752aefd14734de20)
[Issue #3276218 by lauriii: Follow-up to #3268318: Enable link manual decorator unrestricted test case](https://git.drupalcode.org/project/drupal/commit/d57820643304c2e95c82d3e72fe3f3576bd4706d)
[Issue #2636086 by Matroskeen, Spokje, jian he, ravi.shankar, quietone, larowlan, Lendude, dawehner, Sweetchuck: Add extra test coverage for operators of views date filters](https://git.drupalcode.org/project/drupal/commit/fbfc2404a601629c2edc9b785ff830be6ae598a8)
[Issue #3252100 by amateescu, catch, Tim Bozeman: Set revision_default when publishing](https://git.drupalcode.org/project/drupal/commit/9a3a6c1e5eb267f63d64bc71b4b2f1306f8ff845)
[Issue #3269657 by hooroomoo, Wim Leers: [drupalMedia] The CKEditor 4 → 5 upgrade path for the media_embed filter should not forcefully allow the data-view-mode attribute on <drupal-media>](https://git.drupalcode.org/project/drupal/commit/c90ba994030db84630efad70754d55101e2d2030)