### PR TITLE
[GOVCMSD9-777] update Drupal core from 9.3.17 to 9.3.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/contact_storage": "1.2.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.3.17",
+        "drupal/core-recommended": "9.3.18",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.5",


### PR DESCRIPTION
[drupal 9.3.18](https://www.drupal.org/project/drupal/releases/9.3.18)

Release notes

This is a patch (bugfix) release of Drupal 9 and is ready for use on production sites. [Learn more about Drupal 9](https://www.drupal.org/about/9).Drupal 9.3.x will receive security coverage until December 2022.If you are upgrading from Drupal 8, read [upgrading a Drupal 8 site to Drupal 9](https://www.drupal.org/docs/updating-drupal/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/upgrading-a-drupal-8-site), [9.0.0 release notes](https://www.drupal.org/project/drupal/releases/9.0.0), and the [9.3.0 release notes](https://www.drupal.org/project/drupal/releases/9.3.0) before upgrading to this release.

Important update information

[Composer 2.2.0](https://blog.packagist.com/composer-2-2/) introduced a new security feature that requires Composer projects to authorize plugins. This change means that Composer commands to install and update Drupal projects will fail unless either the required plugins are authorized in the project configuration or the user manually replies "y" to a prompt to authorize the plugin. The prompt can break continuous integration and deployment workflows (including Drupal.org's packaging of Drupal core), so it is recommended that projects authorize core's required plugins (and projects using development dependencies should authorize development plugins).This release configures drupal/recommended-project to authorize core's required and development plugins by default. Existing projects may also need to update their configuration to authorize these plugins. For more information, review [Composer 2.2+ authorized plugins](https://www.drupal.org/node/3294646).

Known issues

[Search the issue queue for known issues](https://www.drupal.org/project/issues/search/drupal?project_issue_followers=&status%5B%5D=Open&version%5B%5D=any_10.&version%5B%5D=any_9.&issue_tags_op=%3D).

All changes since 9.3.17
[Issue #3294205 by shaal, NickDickinsonWilde, Spokje, alexpott, xjm, larowlan, longwave: Composer v2.2 prompts to authorize another plugin when stability=dev](https://git.drupalcode.org/project/drupal/commit/98312ea8ca01e840bab5fd146b7000aadfee7590)
[Issue #3255749 by Spokje, alexpott, shaal, longwave, cilefen, AaronMcHale, benjifisher, catch, Mile23: Composer v2.2 prompts to authorize plugins](https://git.drupalcode.org/project/drupal/commit/62d5d9ef5ee5590e4bca9fcb9188d2769157384f)