### PR TITLE
Update Drupal core from 9.3.18 to 9.3.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/contact_storage": "1.2.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.3.18",
+        "drupal/core-recommended": "9.3.19",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7.0",
         "drupal/devel": "4.1.5",


### PR DESCRIPTION
[drupal 9.3.19](https://www.drupal.org/project/drupal/releases/9.3.19)

Release notes

This is a security release of the Drupal 9 series.

This release fixes security vulnerabilities. Sites are [urged to update immediately](https://www.drupal.org/docs/updating-drupal/options-for-updating-drupal-core) after reading the notes below and the security announcement:

    [Drupal core - Moderately critical - Information Disclosure - SA-CORE-2022-012](https://www.drupal.org/sa-core-2022-012)
    [Drupal core - Moderately critical - Access Bypass - SA-CORE-2022-013](https://www.drupal.org/sa-core-2022-013)
    [Drupal core - Critical - Arbitrary PHP code execution - SA-CORE-2022-014](https://www.drupal.org/sa-core-2022-014)
    [Drupal core - Moderately critical - Multiple vulnerabilities - SA-CORE-2022-015](https://www.drupal.org/sa-core-2022-015)

No other changes are included.
Which release do I choose? Security coverage information

    Drupal 9.3.x will receive security coverage [until December 14, 2022 when Drupal 9.5.0 is released](https://www.drupal.org/about/core/policies/core-release-cycles/schedule). Update to Drupal 9.4.x soon to continue receiving security coverage.
    Versions of Drupal 9 prior to 9.3.x are end-of-life and do not receive security coverage.
    Versions of Drupal 8 are end-of-life and do not receive security coverage.

Important update information

    Following this release, Drupal will assume by default that custom stream wrappers (like [Remote Stream Wrapper](https://www.drupal.org/project/remote_stream_wrapper) or [Flysystem](https://www.drupal.org/project/flysystem), among many others) should be private by default so that Drupal will manage downloads and access control. If a module intentionally wishes to serve files with no access checking or management by Drupal, the module should implement hook_file_download().

    Since various contributed stream wrapper modules might not be able to update immediately for this security release, site owners may also specify which stream wrappers should be treated as public stream wrappers (with no access control). If content from a stream wrapper on your site stops working after this update, you can add the following line to settings.php:

    $settings['file_additional_public_schemes'] = ['example'];

    …where example is replaced by the name of the affected stream wrapper. (For example, s3 or https.) The name of the stream wrapper will depend on the affected module and its configuration.

    You should also locate or submit an issue in the module's queue to implement hook_file_download() for this security advisory.

    If the private files directory is inside the public files directory (e.g. drupal/sites/files/private), a site file field misconfiguration or other issue might lead to the site relying on the previous access bypass. If parts of your file or image content become inaccessible after this release, add the following line to your site's settings.php:

    $settings['sa_core_2022_012_override'] = TRUE;

    This setting is a temporary backward-compatibility layer for misconfigured sites and will be removed in a future release. In the long term, you should [migrate your uploaded files to the correct public or private directories](https://www.drupal.org/node/3298661).