### PR TITLE
[GOVCMSD9-872] Configure securitytxt module

### DIFF
--- a/config/install/securitytxt.settings.yml
+++ b/config/install/securitytxt.settings.yml
@@ -1,0 +1,13 @@
+enabled: true
+contact_email: ''
+contact_phone: ''
+contact_page_url: 'https://www.govcms.gov.au/support/security/disclosure'
+encryption_public_key_url: ''
+policy_page_url: ''
+acknowledgement_page_url: ''
+signature_text: ''
+contact_url: ''
+encryption_key_url: ''
+policy_url: ''
+acknowledgement_url: ''
+

--- a/govcms.install
+++ b/govcms.install
@@ -8,6 +8,7 @@
 use Drupal\node\Entity\Node;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\user\RoleInterface;
 
 /**
  * Define a default theme constant.
@@ -127,6 +128,22 @@ function govcms_install() {
       'use_default' => FALSE,
     ])
     ->save(TRUE);
+
+  // Grant the "view securitytxt" permission to all users by default.
+  // The Security Text module is a dependency of GovCMS Security module,
+  // which should be installed already at this point.
+  // govcms_security_update_9001() is doing the same thing as here.
+  // We might remove all updates for GovCMS 10.
+  // That is why we duplicated them here.
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler->moduleExists('user') && $module_handler->moduleExists('securitytxt')) {
+    // Anonymous role.
+    user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, [
+      'view securitytxt']);
+    // Authenticated role.
+    user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, [
+      'view securitytxt']);
+  }
 }
 
 /**

--- a/modules/custom/core/govcms_security/govcms_security.info.yml
+++ b/modules/custom/core/govcms_security/govcms_security.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - password_policy:password_policy_username
   - real_aes
   - seckit:seckit
+  - securitytxt
   - tfa
   - update_notifications_disable:update_notifications_disable
   - username_enumeration_prevention:username_enumeration_prevention

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -4,3 +4,70 @@
  * @file
  * Contains install and update functions for the module.
  */
+use Drupal\user\RoleInterface;
+
+/**
+ * Issue GOVCMSD9-713: Grant 'view securitytxt' permission from security.txt module to all users.
+ */
+function govcms_security_update_9001() {
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler) {
+    // We have to make sure the security text module is installed.
+    if (!($module_handler->moduleExists('securitytxt'))) {
+      if (!(\Drupal::service('module_installer')->install(['securitytxt']))) {
+        return t('"security.txt" module has not been installed.');
+      }
+    }
+    // Grant the "view securitytxt" permission to all users by default.
+    if ($module_handler->moduleExists('user')) {
+      // Anonymous role.
+      user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, [
+        'view securitytxt']);
+      // Authenticated role.
+      user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, [
+        'view securitytxt']);
+    }
+  }
+}
+
+/**
+ * Implements hook_requirements
+ */
+function govcms_security_requirements($phase) {
+  // We only check the requirements during the runtime.
+  if ($phase !== 'runtime') {
+    return [];
+  }
+
+  $requirements = [];
+
+  /* ************************************************************************ */
+  // Dependent modules.
+  /* ************************************************************************ */
+  // Warn if any dependent modules are not installed.
+  // @see system_requirements()
+  $info = \Drupal::service('extension.list.module')->getExtensionInfo('govcms_security');
+  $module_handler = \Drupal::moduleHandler();
+  $dependencies = $info['dependencies'] ?? [];
+  // Modules list that haven't been enabled.
+  $disabled_modules = [];
+
+  if (is_array($dependencies)) {
+    foreach ($dependencies as $module_name) {
+      // Check if the dependent module has been enabled.
+      if (!($module_handler->moduleExists($module_name))) {
+        $disabled_modules[] = $module_name;
+      }
+    }
+
+    if (!empty($disabled_modules)) {
+      $requirements['govcms_security_dependencies'] = [
+        'title' => t("GovCMS Security"),
+        'value' => t('GovCMS security dependency error. Following module must be enable for security reason.'),
+        'description' => t('%module_list', [
+          '%module_list' => implode(', ', $disabled_modules)]),
+        'severity' => REQUIREMENT_ERROR];
+    }
+  }
+  return $requirements;
+}

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -14,7 +14,12 @@ function govcms_security_update_9001() {
   if ($module_handler) {
     // We have to make sure the security text module is installed.
     if (!($module_handler->moduleExists('securitytxt'))) {
+      // The Security Text module hasn't been installed,
+      // then we install that module here.
       if (!(\Drupal::service('module_installer')->install(['securitytxt']))) {
+        // In case the Security Text module wasn't installed successfully,
+        // maybe due to that module doesn't exist in the file system.
+        // Here return a message to indicate that the critical module isn't installed.
         return t('"security.txt" module has not been installed.');
       }
     }


### PR DESCRIPTION
Changes:

- New hook govcms_security_update_9001 to enable the Security Text module for existing GovCMS sites, if it hasn't.
- New feature to  check if any dependencies of GovCMS Security module hasn't been enabled.
- Add default settings for securitytxt module.