### PR TITLE
[GOVCMSD9-695] Step1: Remove update_notifications_disable module from distribution

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -4,7 +4,7 @@ services:
     image: tugboatqa/mysql:5
 
   app:
-    image: tugboatqa/php:7.4-apache
+    image: tugboatqa/php:8.1-apache
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
     #   2. Exposes port 80 to the Tugboat HTTP proxy
@@ -36,6 +36,7 @@ services:
 
         # Install/update packages managed by composer, including drush.
         - composer selfupdate && composer clear
+        - composer require php:"^7.4 || ^8"
         - COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
 
         # Link the document root to the expected path.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -36,7 +36,6 @@ services:
 
         # Install/update packages managed by composer, including drush.
         - composer selfupdate && composer clear
-        - composer require php:"^7.4 || ^8"
         - COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
 
         # Link the document root to the expected path.

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/dynamic_entity_reference": "1.16.0",
         "drupal/embed": "1.5",
         "drupal/encrypt": "3.0",
-        "drupal/entity_browser": "2.7.0",
+        "drupal/entity_browser": "2.8.0",
         "drupal/entity_class_formatter": "1.3",
         "drupal/entity_embed": "1.2.0",
         "drupal/entity_hierarchy": "3.1.2",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "drupal/entity_hierarchy": "3.1.2",
         "drupal/entity_reference_display": "1.4.0",
         "drupal/entity_reference_revisions": "1.9.0",
-        "drupal/environment_indicator": "4.0.6",
+        "drupal/environment_indicator": "4.0.7",
         "drupal/facets": "2.0.5",
         "drupal/fakeobjects": "1.1",
         "drupal/features": "3.12.0",

--- a/config/install/securitytxt.settings.yml
+++ b/config/install/securitytxt.settings.yml
@@ -1,0 +1,13 @@
+enabled: true
+contact_email: ''
+contact_phone: ''
+contact_page_url: 'https://www.govcms.gov.au/support/security/disclosure'
+encryption_public_key_url: ''
+policy_page_url: ''
+acknowledgement_page_url: ''
+signature_text: ''
+contact_url: ''
+encryption_key_url: ''
+policy_url: ''
+acknowledgement_url: ''
+

--- a/govcms.install
+++ b/govcms.install
@@ -179,3 +179,29 @@ function govcms_update_9001() {
     \Drupal::keyValue('system.schema')->delete($stub_module);
   }
 }
+
+/**
+ * Issue GOVCMSD9-695: Remove update_notifications_disable module from distribution.
+ */
+function govcms_update_9002() {
+  $disabling_modules = [
+    'update_notifications_disable',
+  ];
+
+  $extension_config = \Drupal::configFactory()->getEditable('core.extension');
+  $module = $extension_config->get('module');
+
+  foreach($disabling_modules as $disabling_module) {
+    if (isset($module[$disabling_module])) {
+      unset($module[$disabling_module]);
+    }
+  }
+
+  $extension_config->set('module', $module);
+  $extension_config->save();
+
+  // Remove update_notifications_disable module from system.schema.
+  foreach($disabling_modules as $disabling_module) {
+    \Drupal::keyValue('system.schema')->delete($disabling_module);
+  }
+}

--- a/govcms.install
+++ b/govcms.install
@@ -8,6 +8,7 @@
 use Drupal\node\Entity\Node;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\user\RoleInterface;
 
 /**
  * Define a default theme constant.
@@ -127,6 +128,22 @@ function govcms_install() {
       'use_default' => FALSE,
     ])
     ->save(TRUE);
+
+  // Grant the "view securitytxt" permission to all users by default.
+  // The Security Text module is a dependency of GovCMS Security module,
+  // which should be installed already at this point.
+  // govcms_security_update_9001() is doing the same thing as here.
+  // We might remove all updates for GovCMS 10.
+  // That is why we duplicated them here.
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler->moduleExists('user') && $module_handler->moduleExists('securitytxt')) {
+    // Anonymous role.
+    user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, [
+      'view securitytxt']);
+    // Authenticated role.
+    user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, [
+      'view securitytxt']);
+  }
 }
 
 /**

--- a/modules/custom/core/govcms_security/govcms_security.info.yml
+++ b/modules/custom/core/govcms_security/govcms_security.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - password_policy:password_policy_username
   - real_aes
   - seckit:seckit
+  - securitytxt
   - tfa
   - update_notifications_disable:update_notifications_disable
   - username_enumeration_prevention:username_enumeration_prevention

--- a/modules/custom/core/govcms_security/govcms_security.info.yml
+++ b/modules/custom/core/govcms_security/govcms_security.info.yml
@@ -19,5 +19,4 @@ dependencies:
   - seckit:seckit
   - securitytxt
   - tfa
-  - update_notifications_disable:update_notifications_disable
   - username_enumeration_prevention:username_enumeration_prevention

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -58,7 +58,11 @@ function govcms_security_requirements($phase) {
   $disabled_modules = [];
 
   if (is_array($dependencies)) {
-    foreach ($dependencies as $module_name) {
+    foreach ($dependencies as $dependency_name) {
+      // The dependency name could be {module}:{submodule}
+      // or {module}:{module}.
+      $project_module_name = explode(':', $dependency_name);
+      $module_name = $project_module_name[1] ?? $project_module_name[0];
       // Check if the dependent module has been enabled.
       if (!($module_handler->moduleExists($module_name))) {
         $disabled_modules[] = $module_name;

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -4,3 +4,70 @@
  * @file
  * Contains install and update functions for the module.
  */
+use Drupal\user\RoleInterface;
+
+/**
+ * Issue GOVCMSD9-713: Grant 'view securitytxt' permission from security.txt module to all users.
+ */
+function govcms_security_update_9001() {
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler) {
+    // We have to make sure the security text module is installed.
+    if (!($module_handler->moduleExists('securitytxt'))) {
+      if (!(\Drupal::service('module_installer')->install(['securitytxt']))) {
+        return t('"security.txt" module has not been installed.');
+      }
+    }
+    // Grant the "view securitytxt" permission to all users by default.
+    if ($module_handler->moduleExists('user')) {
+      // Anonymous role.
+      user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, [
+        'view securitytxt']);
+      // Authenticated role.
+      user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, [
+        'view securitytxt']);
+    }
+  }
+}
+
+/**
+ * Implements hook_requirements
+ */
+function govcms_security_requirements($phase) {
+  // We only check the requirements during the runtime.
+  if ($phase !== 'runtime') {
+    return [];
+  }
+
+  $requirements = [];
+
+  /* ************************************************************************ */
+  // Dependent modules.
+  /* ************************************************************************ */
+  // Warn if any dependent modules are not installed.
+  // @see system_requirements()
+  $info = \Drupal::service('extension.list.module')->getExtensionInfo('govcms_security');
+  $module_handler = \Drupal::moduleHandler();
+  $dependencies = $info['dependencies'] ?? [];
+  // Modules list that haven't been enabled.
+  $disabled_modules = [];
+
+  if (is_array($dependencies)) {
+    foreach ($dependencies as $module_name) {
+      // Check if the dependent module has been enabled.
+      if (!($module_handler->moduleExists($module_name))) {
+        $disabled_modules[] = $module_name;
+      }
+    }
+
+    if (!empty($disabled_modules)) {
+      $requirements['govcms_security_dependencies'] = [
+        'title' => t("GovCMS Security"),
+        'value' => t('GovCMS security dependency error. Following module must be enable for security reason.'),
+        'description' => t('%module_list', [
+          '%module_list' => implode(', ', $disabled_modules)]),
+        'severity' => REQUIREMENT_ERROR];
+    }
+  }
+  return $requirements;
+}

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -14,7 +14,12 @@ function govcms_security_update_9001() {
   if ($module_handler) {
     // We have to make sure the security text module is installed.
     if (!($module_handler->moduleExists('securitytxt'))) {
+      // The Security Text module hasn't been installed,
+      // then we install that module here.
       if (!(\Drupal::service('module_installer')->install(['securitytxt']))) {
+        // In case the Security Text module wasn't installed successfully,
+        // maybe due to that module doesn't exist in the file system.
+        // Here return a message to indicate that the critical module isn't installed.
         return t('"security.txt" module has not been installed.');
       }
     }

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -184,3 +184,11 @@ function govcms_security_hide_permissions_default() {
     'administer module_permissions',
   ];
 }
+
+/**
+ * Implements hook_update_projects_alter().
+ * Disables updates from all modules
+ */
+function update_notifications_disable_update_projects_alter(&$projects) {
+  $projects = [];
+}


### PR DESCRIPTION
Step 1 to remove [update_notifications_disable](https://www.drupal.org/project/update_notifications_disable) from distribution: Copy the update_notifications_disable module functionality into govcms.security.module and disable the update_notifications_disable module in distro install hook.
