### PR TITLE
[GOVCMSD9-883] Lock Security.txt in GovCMS

### DIFF
--- a/config/install/user.role.govcms_site_administrator.yml
+++ b/config/install/user.role.govcms_site_administrator.yml
@@ -39,6 +39,7 @@ permissions:
   - 'administer node fields'
   - 'administer node form display'
   - 'administer nodes'
+  - 'administer securitytxt'
   - 'administer shortcuts'
   - 'administer taxonomy'
   - 'administer taxonomy_term display'

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -36,6 +36,33 @@ function govcms_security_update_9001() {
 }
 
 /**
+ * Issue GOVCMSD9-883: Grant 'administer securitytxt' permission to site administrator.
+ */
+function govcms_security_update_9002() {
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler) {
+    // We have to make sure the security text module is installed,
+    // before granting the permission to user roles.
+    if (!($module_handler->moduleExists('securitytxt'))) {
+      // The Security Text module hasn't been installed,
+      // then we install that module here.
+      if (!(\Drupal::service('module_installer')->install(['securitytxt']))) {
+        // In case the Security Text module wasn't installed successfully,
+        // maybe due to that module doesn't exist in the file system.
+        // Here return a message to indicate that the critical module isn't installed.
+        return t('"security.txt" module has not been installed.');
+      }
+    }
+    // Grant the "administer securitytxt" permission to user roles.
+    if ($module_handler->moduleExists('user')) {
+      // Govcms site administrator role.
+      user_role_grant_permissions(GovcmsSecurityInterface::GOVCMS_SITE_ADMIN_ROLE, [
+        'administer securitytxt']);
+    }
+  }
+}
+
+/**
  * Implements hook_requirements
  */
 function govcms_security_requirements($phase) {

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -39,6 +39,17 @@ function govcms_security_form_user_admin_settings_alter(&$form, FormStateInterfa
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function govcms_security_form_securitytxt_configure_alter(&$form, &$form_state) {
+  // Security.txt must be enabled.
+  $form['enabled']['#default_value'] = 1;
+  // Hide the 'enable' check box, so that no one can change it,
+  // via the form.
+  $form['enabled']['#access'] = FALSE;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function govcms_security_form_user_admin_permissions_alter(&$form, FormStateInterface $form_state) {
   $banned_permissions = govcms_security_hide_permissions_default();
   $permissions = \Drupal::service('user.permissions')->getPermissions();

--- a/modules/custom/core/govcms_security/src/GovcmsSecurityInterface.php
+++ b/modules/custom/core/govcms_security/src/GovcmsSecurityInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\govcms_security;
+
+/**
+ * Provides an interface for GovCMS secruity constants.
+ */
+interface GovcmsSecurityInterface {
+  /**
+   * Role ID for GovCMS Site Administrator role.
+   */
+  const GOVCMS_SITE_ADMIN_ROLE = 'govcms_site_administrator';
+}


### PR DESCRIPTION
Changes:

- Grant the 'Administer security.txt' permission to site admin user role, so that they are able to modify the details of Security.txt via the config form for their own site.
- Hide the 'enable' checkbox in the config form and set the default value to 1, so that no one can disable the Security.txt via the form.
