### PR TITLE
[GOVCMSD9-907] Include captcha module in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "drupal/adminimal_theme": "1.6.0",
         "drupal/bigmenu": "2.0.0-rc2",
         "drupal/block_place": "1.0",
+        "drupal/captcha": "1.4",
         "drupal/chosen": "3.0.3",
         "drupal/components": "2.4.0",
         "drupal/config_filter": "2.4.0",


### PR DESCRIPTION
https://www.drupal.org/project/captcha/releases/8.x-1.4

At present captcha module is not set in composer.json (https://github.com/govCMS/GovCMS/blob/2.x-master/composer.json) but comes in as a dependency in recaptcha. As a dependency, it will auto update to the latest release which means we have not had the chance to test it. This update is to add captcha to composer.json and fix it to a version which we have tested.