### PR TITLE
[GOVCMSD9-695] Step1: Remove update_notifications_disable module from distribution

### DIFF
--- a/govcms.install
+++ b/govcms.install
@@ -179,3 +179,29 @@ function govcms_update_9001() {
     \Drupal::keyValue('system.schema')->delete($stub_module);
   }
 }
+
+/**
+ * Issue GOVCMSD9-695: Remove update_notifications_disable module from distribution.
+ */
+function govcms_update_9002() {
+  $disabling_modules = [
+    'update_notifications_disable',
+  ];
+
+  $extension_config = \Drupal::configFactory()->getEditable('core.extension');
+  $module = $extension_config->get('module');
+
+  foreach($disabling_modules as $disabling_module) {
+    if (isset($module[$disabling_module])) {
+      unset($module[$disabling_module]);
+    }
+  }
+
+  $extension_config->set('module', $module);
+  $extension_config->save();
+
+  // Remove update_notifications_disable module from system.schema.
+  foreach($disabling_modules as $disabling_module) {
+    \Drupal::keyValue('system.schema')->delete($disabling_module);
+  }
+}

--- a/modules/custom/core/govcms_security/govcms_security.info.yml
+++ b/modules/custom/core/govcms_security/govcms_security.info.yml
@@ -19,5 +19,4 @@ dependencies:
   - seckit:seckit
   - securitytxt
   - tfa
-  - update_notifications_disable:update_notifications_disable
   - username_enumeration_prevention:username_enumeration_prevention

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -86,7 +86,7 @@ function govcms_security_requirements($phase) {
  *
  * Ensure that the Available releases array is empty so it never checks them.
  */
-function update_notifications_disable_install($is_syncing) {
+function govcms_security_install($is_syncing) {
   \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
   \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
 }

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -80,3 +80,13 @@ function govcms_security_requirements($phase) {
   }
   return $requirements;
 }
+
+/**
+ * Implements hook_install().
+ *
+ * Ensure that the Available releases array is empty so it never checks them.
+ */
+function update_notifications_disable_install($is_syncing) {
+  \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
+  \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
+}

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -189,7 +189,7 @@ function govcms_security_hide_permissions_default() {
  * Implements hook_update_projects_alter().
  * Disables updates from all modules
  */
-function update_notifications_disable_update_projects_alter(&$projects) {
+function govcms_security_update_projects_alter(&$projects) {
   \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
   \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
   $projects = [];
@@ -200,7 +200,7 @@ function update_notifications_disable_update_projects_alter(&$projects) {
  *
  * Make sure that when cron runs, available data is not fetched.
  */
-function update_notifications_disable_cron() {
+function govcms_security_cron() {
   \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
   \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
 }

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -184,3 +184,23 @@ function govcms_security_hide_permissions_default() {
     'administer module_permissions',
   ];
 }
+
+/**
+ * Implements hook_update_projects_alter().
+ * Disables updates from all modules
+ */
+function update_notifications_disable_update_projects_alter(&$projects) {
+  \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
+  \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
+  $projects = [];
+}
+
+/**
+ * Implements hook_cron().
+ *
+ * Make sure that when cron runs, available data is not fetched.
+ */
+function update_notifications_disable_cron() {
+  \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
+  \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
+}


### PR DESCRIPTION
Step 1 to remove [update_notifications_disable](https://www.drupal.org/project/update_notifications_disable) from distribution: Copy the update_notifications_disable module functionality into govcms.security.module and govcms.security.module, and disable the update_notifications_disable module in distro install hook.