### PR TITLE
[GOVCMSD9-878] add entity_embed patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,8 +187,8 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-          "drupal/captcha": {
-              "Captcha point add label": "https://www.drupal.org/files/issues/2022-08-07/hook-3293710-3.patch"
+          "drupal/entity_embed": {
+              "Construction of EntityEmbedDisplay plugin instances trigger strpos deprecation on PHP 8.1": "https://git.drupalcode.org/project/entity_embed/-/merge_requests/6.diff"
           },
             "drupal/google_analytics": {
                 "Fix deprecated warnings for PHP 8.1 compatibility - https://www.drupal.org/project/google_analytics/issues/3258588": "https://www.drupal.org/files/issues/2022-06-03/google_analytics-jsonserialize-code-standard-fixes-3258588-20.patch"


### PR DESCRIPTION
Patch Entity Embed to avoid PHP 8.1 warnings
Issue - https://www.drupal.org/project/entity_embed/issues/3260833

Patch - https://git.drupalcode.org/project/entity_embed/-/merge_requests/6.diff