### PR TITLE
[GOVCMSD9-877] add linkit patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,8 +187,8 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-          "drupal/captcha": {
-              "Captcha point add label": "https://www.drupal.org/files/issues/2022-08-07/hook-3293710-3.patch"
+          "drupal/linkit": {
+              "Deprecated function : Return type of Drupal\linkit\Suggestion\SimpleSuggestion::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize()": "https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch"
           },
             "drupal/google_analytics": {
                 "Fix deprecated warnings for PHP 8.1 compatibility - https://www.drupal.org/project/google_analytics/issues/3258588": "https://www.drupal.org/files/issues/2022-06-03/google_analytics-jsonserialize-code-standard-fixes-3258588-20.patch"

--- a/composer.json
+++ b/composer.json
@@ -188,7 +188,7 @@
         "composer-exit-on-patch-failure": true,
         "patches": {
           "drupal/linkit": {
-              "Deprecated function : Return type of Drupal\linkit\Suggestion\SimpleSuggestion::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize()": "https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch"
+              "Deprecated function": "https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch"
           },
             "drupal/google_analytics": {
                 "Fix deprecated warnings for PHP 8.1 compatibility - https://www.drupal.org/project/google_analytics/issues/3258588": "https://www.drupal.org/files/issues/2022-06-03/google_analytics-jsonserialize-code-standard-fixes-3258588-20.patch"


### PR DESCRIPTION
Patch Linkit to avoid PHP 8.1 warnings
Issue - https://www.drupal.org/project/linkit/issues/3262401

Patch - https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch