### PR TITLE
[GOVCMSD9-877] add linkit patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -206,6 +206,9 @@
             },
             "drupal/twig_tweak": {
                 "sanitize input": "https://www.drupal.org/files/issues/2021-02-03/twig_tweak-token-xss.patch"
+            },
+            "drupal/linkit": {
+                "Deprecated function": "https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch"
             }
         }
     },


### PR DESCRIPTION
Patch Linkit to avoid PHP 8.1 warnings
Issue - https://www.drupal.org/project/linkit/issues/3262401

Patch - https://www.drupal.org/files/issues/2022-04-26/linkit-jsonserialize-3262401-11.patch