### PR TITLE
[GOVCMSD9-912] Remove patch for google_analytics deprecated warnings for PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,9 +187,6 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-            "drupal/google_analytics": {
-                "Fix deprecated warnings for PHP 8.1 compatibility - https://www.drupal.org/project/google_analytics/issues/3258588": "https://www.drupal.org/files/issues/2022-06-03/google_analytics-jsonserialize-code-standard-fixes-3258588-20.patch"
-            },
             "drupal/metatag": {
                 "Unsetting metatags": "https://www.drupal.org/files/issues/2022-03-15/metatag-unset-2735195.patch"
             },


### PR DESCRIPTION
https://www.drupal.org/files/issues/2022-06-03/google_analytics-jsonserialize-code-standard-fixes-3258588-20.patch is included in google_analytics 4.0.2 https://www.drupal.org/project/google_analytics/releases/4.0.2. 