### PR TITLE
[GOVCMSD9-876] Remove update_notifications_disable module from the distribution codebase (Step 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,6 @@
         "drupal/tfa": "1.0.0-alpha8",
         "drupal/token": "1.11.0",
         "drupal/twig_tweak": "2.9",
-        "drupal/update_notifications_disable": "1.1",
         "drupal/username_enumeration_prevention": "1.2.0",
         "drupal/video_embed_field": "2.4",
         "drupal/webform": "6.1.3",


### PR DESCRIPTION
Step 2 of removing update_notifications_disable (https://www.drupal.org/project/update_notifications_disable) module and implement change in govcms_security.

We will do this in two steps:
Step 1: The module has been disabled in distro install hook as part of GovCMS 2.23.0 release ([GOVCMSD9-695]
Step 2: The module to be removed from the codebase in the following release GovCMS 2.24.0 (GOVCMSD9-876)