### PR TITLE
[GOVCMSD9-935] Fix the deprecated function in govcms.profile

### DIFF
--- a/govcms.install
+++ b/govcms.install
@@ -113,7 +113,7 @@ function govcms_install() {
     ->save(TRUE);
 
   // Set the path to the logo, favicon and README file based on install directory.
-  $govcms_path = drupal_get_path('profile', 'govcms');
+  $govcms_path = \Drupal::service('extension.list.profile')->getPath('govcms');
   \Drupal::configFactory()
     ->getEditable('system.theme.global')
     ->set('logo', [


### PR DESCRIPTION
Problem/Motivation
Error: Call to undefined function drupal_get_path() in /app/web/profiles/govcms/govcms.install on line 116 #0 [internal function]: govcms_install(false)

Proposed resolution
Fix it with the correct function