### PR TITLE
[GOVCMSD9-619] Remove drupal/ga_login module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,6 @@
         "drupal/features": "3.12.0",
         "drupal/field_group": "3.3.0",
         "drupal/focal_point": "1.5.0",
-        "drupal/ga_login": "1.0.0-alpha6",
         "drupal/google_analytics": "4.0.2",
         "drupal/govcms_dlm": "1.4.0",
         "drupal/honeypot": "2.1.1",


### PR DESCRIPTION
This removes the ga_login module which has now been [merged into drupal/tfa](https://www.drupal.org/project/tfa/issues/3208224), is no longed required, and is [no longer supported](https://www.drupal.org/project/ga_login).