### PR TITLE
[GOVCMSD9-995] Update Drupal core from 9.4.8 to 9.4.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
         "drupal/devel": "4.2.1",
-        "drupal/core-recommended": "9.4.8",
+        "drupal/core-recommended": "9.4.9",
         "drupal/crop": "2.3.0",
         "drupal/ctools": "3.13.0",
         "drupal/diff": "1.1.0",


### PR DESCRIPTION
**drupal 9.4.9**
https://www.drupal.org/project/drupal/releases/9.4.9

**Release notes**
This is a patch (bugfix) release of Drupal 9 and is ready for use on production sites. [Learn more about Drupal 9](https://www.drupal.org/about/9).

This is the final normal bugfix release of Drupal 9.4.x. It will receive security coverage until June 2023. Plan to upgrade to Drupal 9.5 or 10.0 soon to continue receiving bug fixes and new features.

If you are upgrading from Drupal 8, read [upgrading a Drupal 8 site to Drupal 9](https://www.drupal.org/docs/updating-drupal/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/upgrading-a-drupal-8-site), [9.0.0 release notes](https://www.drupal.org/project/drupal/releases/9.0.0), and the [9.4.0 release notes](https://www.drupal.org/project/drupal/releases/9.4.0) before upgrading to this release.