### PR TITLE
[GOVCMSD9-1014] [SA-CORE-2023-001] Update Drupal core from 9.4.9 to 9.4.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
         "drupal/devel": "5.0.2",
-        "drupal/core-recommended": "9.4.9",
+        "drupal/core-recommended": "9.4.10",
         "drupal/crop": "2.3.0",
         "drupal/ctools": "3.13.0",
         "drupal/diff": "1.1.0",


### PR DESCRIPTION
**[SA-CORE-2023-001] Drupal core - Moderately critical - Information Disclosure**
Security Advisory - https://www.drupal.org/sa-core-2023-001
**Solution:** 
Install the latest version:
If you are using Drupal 9.4, update to [Drupal 9.4.10](https://www.drupal.org/project/drupal/releases/9.4.10).
