### PR TITLE
[GOVCMSD9-1015] [SA-CONTRIB-2023-002] Update drupal/entity_browser module from 2.8.0 to 2.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "drupal/dynamic_entity_reference": "1.16.0",
         "drupal/embed": "1.6.0",
         "drupal/encrypt": "3.1.0",
-        "drupal/entity_browser": "2.8.0",
+        "drupal/entity_browser": "2.9.0",
         "drupal/entity_embed": "1.3.0",
         "drupal/entity_class_formatter": "2.0.0",
         "drupal/entity_hierarchy": "3.3.3",


### PR DESCRIPTION
**Security Advisory - https://www.drupal.org/sa-contrib-2023-002**

**Solution:** 
Install the latest version:
If you use the Entity Browser module for Drupal 9 or 10, upgrade to [Entity Browser 8.x-2.9](https://www.drupal.org/project/entity_browser/releases/8.x-2.9).
