### PR TITLE
[GOVCMSD10-44] Update drupal/layout_builder_restrictions module from 2.17.0 to 2.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "drupal/inline_entity_form": "1.0.0-rc15",
         "drupal/key": "1.17.0",
         "drupal/layout_builder_modal": "1.2.0",
-        "drupal/layout_builder_restrictions": "2.17.0",
+        "drupal/layout_builder_restrictions": "2.18.0",
         "drupal/linked_field": "1.5.0",
         "drupal/linkit": "6.0.0-rc1",
         "drupal/login_security": "2.0.1",


### PR DESCRIPTION
### layout_builder_restrictions 8.x-2.18

https://www.drupal.org/project/layout_builder_restrictions/releases/8.x-2.18

Release notes
Contributors (2)

[mark_fullmer](https://www.drupal.org/u/mark_fullmer), [ihor_allin](https://www.drupal.org/u/ihor_allin)

Changelog

Issues: 1 issues resolved.

Changes since [8.x-2.17](https://www.drupal.org/project/layout_builder_restrictions/releases/8.x-2.17):

Feature

[#3305449](https://www.drupal.org/node/3305449) by [mark_fullmer](https://www.drupal.org/u/mark_fullmer), [ihor_allin](https://www.drupal.org/u/ihor_allin): Allow restrictions to remain after disabling a layout