### PR TITLE
[GOVCMSD10-89] Add CKEditor 4 as contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "drupal/bigmenu": "2.0.0-rc3",
         "drupal/captcha": "2.0.0",
         "drupal/chosen": "4.0.0",
+        "drupal/ckeditor": "1.0.2",
         "drupal/components": "3.0.0-beta3",
         "drupal/config_filter": "2.4.0",
         "drupal/config_ignore": "2.4.0",

--- a/govcms.post_update.php
+++ b/govcms.post_update.php
@@ -62,29 +62,6 @@ function govcms_post_update_replace_pathauto_node_type_condition() {
   }
 }
 
-/**
- * Replaces the CKEditor to 5 from 4.
- */
-function govcms_post_update_replace_ckeditor5() {
-  $config_factory = \Drupal::configFactory();
-  foreach ($config_factory->listAll('editor.editor.') as $editor_config_name) {
-    $editor = $config_factory->getEditable($editor_config_name);
-
-    if ($editor->get('editor') == 'ckeditor') {
-      // Set ckeditor5 as a dependency module.
-      $editor->set('dependencies.module', ['ckeditor5']);
-      // Set the editor to ckeditor5.
-      $editor->set('editor', 'ckeditor5');
-      // Set the default settings for ckeditor5.
-      $settings = [
-        // Add any additional settings as needed.
-      ];
-      $editor->set('settings', $settings);
-      // Save the updated configuration.
-      $editor->save();
-    }
-  }
-}
 
 /**
  * Removes the video_embed_wysiwyg plugin from text filters.

--- a/modules/obsolete/ckeditor/ckeditor.info.yml
+++ b/modules/obsolete/ckeditor/ckeditor.info.yml
@@ -1,7 +1,0 @@
-name: CKEditor 4 (contrib)
-type: module
-description: "WYSIWYG editing for rich text fields using CKEditor. [obsolete]"
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
We have made a decision to keep CKEditor 4 in the distro as a contrib module until EOL December 2023.  This will give time for CKEditor 5 to hopefully, fix its short comings and allow our customers to transition more gracefully.

https://www.drupal.org/project/ckeditor

 

**Tasks to complete this:**

add contrib module
Remove update hook
https://github.com/govCMS/GovCMS/blob/3.x-develop/govcms.post_update.php#L68
Remove stub module
https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/ckeditor