### PR TITLE
Support v1 and 2 of Inline Entity Form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "drupal/google_analytics": "4.0.2",
         "drupal/govcms_dlm": "2.0.0",
         "drupal/honeypot": "2.1.2",
-        "drupal/inline_entity_form": "2.0.0-rc4",
+        "drupal/inline_entity_form": "2.0.0-rc4 || 1.0.0-rc15",
         "drupal/key": "1.17.0",
         "drupal/layout_builder_modal": "1.2.0",
         "drupal/layout_builder_restrictions": "2.18.0",


### PR DESCRIPTION
When using GovCMS in PAAS mode, its not possible to keep a dependency on govcms/govcms and install drupal/ief_table_view_mode which required v1 of inline entity form.

Both v1 and 2 have D10 support, so I think installing either version should be allowed.