### PR TITLE
[GOVCMSD10-123] Update drupal/linkit module from 6.0.0 to 6.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "drupal/layout_builder_modal": "1.2.0",
         "drupal/layout_builder_restrictions": "2.19.0",
         "drupal/linked_field": "1.5.0",
-        "drupal/linkit": "6.0.0",
+        "drupal/linkit": "6.1.0",
         "drupal/login_security": "2.0.1",
         "drupal/media_entity_file_replace": "1.1.0",
         "drupal/media_file_delete": "1.3.0",


### PR DESCRIPTION
### linkit 6.1.0
https://www.drupal.org/project/linkit/releases/6.1.0

**Release notes**
This is the first full release of Linkit 6.1.x. It is compatible with Drupal 10.1 and higher. It does not include functional changes beyond what was in the previous release, 6.1.0-rc2.

Changes since [6.1.0-rc2](https://www.drupal.org/project/linkit/releases/6.1.0-rc2):

Task

[#3373257](https://www.drupal.org/node/3373257) by [mark_fullmer](https://www.drupal.org/u/mark_fullmer): Communicate upcoming Drupal core linking enhancement