### PR TITLE
[GOVCMSD10-136] Grant view_securitytxt permission by default to both anonymous and authenticated user roles

### DIFF
--- a/includes/govcms.install.inc
+++ b/includes/govcms.install.inc
@@ -42,5 +42,19 @@ function govcms_modules_installed($modules, $is_syncing) {
         $role->save();
       }
     }
+
+    if (in_array('securitytxt', $modules)) {
+      // Anonymous user.
+      if ($role = Role::load('anonymous')) {
+        $role->grantPermission('view_securitytxt');
+        $role->save();
+      }
+
+      // Authenticated user.
+      if ($role = Role::load('authenticated')) {
+        $role->grantPermission('view_securitytxt');
+        $role->save();
+      }
+    }
   }
 }


### PR DESCRIPTION
View Security.txt - permission NOT granted BY DEFAULT to both the Anonymous and Authenticated user roles