### PR TITLE
[GOVCMSD10-139] Apply patch to fix drupal/honeypot - Missing primary key in table 'honeypot_user'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,9 @@
             },
             "drupal/tfa": {
                 "Create Email one-time-code Validation Plugin & related Setup Plugin - https://www.drupal.org/project/tfa/issues/2930541": "https://www.drupal.org/files/issues/2023-07-19/tfa-2930541-81.patch"
+            },
+            "drupal/honeypot": {
+                "Fix missing primary key in table `honeypot_user` - https://www.drupal.org/project/honeypot/issues/2943526": "https://www.drupal.org/files/issues/2023-07-10/honeypot-add_primary_key-2943526-64.patch"
             }
         }
     },


### PR DESCRIPTION
Error in logs:

READ-COMMITTED

For this to work correctly, all tables must have a primary key. The following table(s) do not have a primary key: honeypot_user 

Related issue in drupal.org: https://www.drupal.org/project/honeypot/issues/2943526

Patch - https://www.drupal.org/files/issues/2023-07-10/honeypot-add_primary_key-2943526-64.patch