### PR TITLE
[GOVCMSD10-224] Remove Aggregator stub module from D10 distro

### DIFF
--- a/modules/obsolete/aggregator/aggregator.info.yml
+++ b/modules/obsolete/aggregator/aggregator.info.yml
@@ -1,7 +1,0 @@
-name: Aggregator
-type: module
-description: 'Gathers and displays syndicated content (RSS, RDF, and Atom feeds) from external sources. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Aggregator stub module to be removed from D10 distro as the module is in lagoon now.

https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/aggregator 