### PR TITLE
[GOVCMSD10-226] Remove Panelizer stub module from D10 distro

### DIFF
--- a/modules/obsolete/panelizer/panelizer.info.yml
+++ b/modules/obsolete/panelizer/panelizer.info.yml
@@ -1,7 +1,0 @@
-name: Panelizer
-type: module
-description: 'Allow any entity view mode to be rendered using a Panels display. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Panelizer stub module to be removed from D10 distro as the module is in lagoon now.

https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/panelizer