### PR TITLE
[GOVCMSD10-231] Apply patch for Drupal 10 error with search_api_attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,6 +179,9 @@
             },
             "drupal/honeypot": {
                 "Fix missing primary key in table `honeypot_user` - https://www.drupal.org/project/honeypot/issues/2943526": "https://www.drupal.org/files/issues/2023-07-10/honeypot-add_primary_key-2943526-64.patch"
+            },
+            "drupal/search_api_attachments": {
+                "Fix fatal error call to Bytes::toInt in file extractor - https://www.drupal.org/project/search_api_attachments/issues/3358930": "https://www.drupal.org/files/issues/2023-08-01/3358930-change-deprecated-toInt.patch"
             }
         }
     },


### PR DESCRIPTION
REF: [[#21114] Drupal 10 error with search_api_attachments for industry2 : GovCMS Service Desk](https://www.govcms.support/a/tickets/21114)
If you set a max upload size under the file attachments processor in search api configuration it throws an error to an undefined method Drupal\Component\Utility\Bytes::toInt() when you see any search results that reference any indexed file. This method has been removed in Drupal 10.

Error: Call to undefined method Drupal\Component\Utility\Bytes::toInt() in Drupal\search_api_attachments\ExtractFileValidator->isFileSizeAllowed() (line 87 of /app/web/modules/contrib/search_api_attachments/src/ExtractFileValidator.php) #0 /app/web/modules/contrib/search_api_attachments/src/Plugin/search_api/processor/FilesExtractor.php(449): Drupal\search_api_attachments\ExtractFileValidator->isFileSizeAllowed()|

Issue in drupal.org: https://www.drupal.org/project/search_api_attachments/issues/3358930

Patch link: https://www.drupal.org/files/issues/2023-08-01/3358930-change-deprecated-toInt.patch