### PR TITLE
[GOVCMSD10-232] Block file extensions from being uploaded.

### DIFF
--- a/config/install/field.field.media.document.field_media_document.yml
+++ b/config/install/field.field.media.document.field_media_document.yml
@@ -21,7 +21,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages'
+  file_extensions: 'txt docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages'
   max_filesize: ''
   handler: 'default:file'
   handler_settings: {  }

--- a/modules/custom/core/govcms_security/govcms_security.install
+++ b/modules/custom/core/govcms_security/govcms_security.install
@@ -19,3 +19,28 @@ function govcms_security_install($is_syncing) {
 function govcms_security_update_last_removed() {
   return 9005;
 }
+
+/**
+ * Remove rtf and doc file extension from the file field.
+ */
+function govcms_security_update_10001() {
+  $extension_config = \Drupal::configFactory()->getEditable('field.field.media.document.field_media_document');
+
+  if (!empty($extension_config)) {
+    $settings = $extension_config->get('settings');
+    if (isset($settings['file_extensions'])) {
+      $file_extensions = explode(' ', $settings['file_extensions']);
+      // Remove rtf extension.
+      if (($key = array_search('rtf', $file_extensions)) !== false) {
+        unset($file_extensions[$key]);
+      }
+      // Remove doc extension.
+      if (($key = array_search('doc', $file_extensions)) !== false) {
+        unset($file_extensions[$key]);
+      }
+
+      $settings['file_extensions'] = implode(' ', $file_extensions);
+      $extension_config->set('settings', $settings)->save();
+    }
+  }
+}

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -11,6 +11,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Extension\Extension;
+use Drupal\file\FileInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 use Drupal\webform\Plugin\WebformElement\ManagedFile;
@@ -225,4 +226,28 @@ function govcms_security_update_projects_alter(&$projects) {
 function govcms_security_cron() {
   \Drupal::keyValueExpirable('update_available_releases')->deleteAll();
   \Drupal::keyValueExpirable('update_available_releases')->setMultiple([]);
+}
+
+/**
+ * Implements hook_file_validate().
+ *
+ * Validate files uploaded.
+ */
+function govcms_security_file_validate(FileInterface $file) {
+  $errors = [];
+  $file_name = $file->getFilename();
+  $blocked_ext = [
+    'doc',
+    'rtf',
+  ];
+
+  if ($file_name) {
+    // Block certain file extensions from being uploaded.
+    $ext = pathinfo($file_name, PATHINFO_EXTENSION);
+    if (in_array($ext, $blocked_ext)) {
+      $errors[] = t("The file's extension '@ext' is not allowed to upload.", ['@ext' => $ext]);
+    }
+  }
+
+  return $errors;
 }


### PR DESCRIPTION
1. Add a file validation hook to prevent rtf and doc file from being uploaded.
2. Remove the rtf and doc file extension from the file field configuration.
3. Create a new database update hook (govcms_security_update_10001) to remove the rtf and doc extension from existing file field configuration.