### PR TITLE
[GOVCMSD10-244] Update Chosen JS to 2.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         {
             "type": "package",
             "package": {
-                "name": "harvesthq/chosen",
-                "version": "v1.8.7",
+                "name": "jjj/chosen",
+                "version": "2.2.1",
                 "type": "drupal-library",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/harvesthq/chosen/releases/download/v1.8.7/chosen_v1.8.7.zip"
+                    "url": "https://github.com/JJJ/chosen/archive/refs/tags/2.2.1.zip"
                 }
             }
         },


### PR DESCRIPTION
Since drupal/chosen 4.0.0, the required library has been changed to https://github.com/JJJ/chosen 2.2.1.

Details see: https://git.drupalcode.org/project/chosen/-/commit/eb8ffc2d66969a9e720d36812a0bab6f096b3d44

The new library fixed a bug with Claro theme which is  reported to https://www.drupal.org/project/chosen/issues/3386364

