### PR TITLE
[GOVCMSD9-1205] Update Drupal core from 9.5.9 to 9.5.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "drupal/contact_storage": "1.3.0",
         "drupal/context": "4.1.0",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "9.5.9",
+        "drupal/core-recommended": "9.5.11",
         "drupal/devel": "5.1.1",
         "drupal/crop": "2.3.0",
         "drupal/ctools": "3.13.0",
@@ -179,9 +179,6 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-            "drupal/core": {
-                "[regression] route defaults are now automatically route parameters - https://www.drupal.org/project/drupal/issues/3358402": "https://www.drupal.org/files/issues/2023-05-10/3359511-revert-3277784-2.patch"
-            },
             "drupal/login_security": {
                 "Correctly detect invalid username/password or blocked account login errors - https://www.drupal.org/project/login_security/issues/3292974": "https://www.drupal.org/files/issues/2023-02-14/login_security-3292974-21.patch"
             },


### PR DESCRIPTION
An previous issue with the Drupal core (https://www.drupal.org/project/drupal/issues/3358402) has been already patched in Drupal 9.5.10. So we can remove the patch for that issue as well.