### PR TITLE
[GOVCMSD10-235] Fix PHP Error - Symfony Mailer - update drupal/symfony_mailer module to 1.4.0-beta2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
         "drupal/simple_oauth": "5.2.3",
         "drupal/simple_sitemap": "4.1.6",
         "drupal/swiftmailer": "2.4.0",
-        "drupal/symfony_mailer": "1.3.1",
+        "drupal/symfony_mailer": "1.4.0-beta2",
         "drupal/tfa": "1.2.0",
         "drupal/token": "1.12.0",
         "drupal/twig_tweak": "3.2.1",


### PR DESCRIPTION
This issue [#3371042](https://www.drupal.org/project/symfony_mailer/issues/3371042) - is fixed in version 1.4.0-beta2 https://www.drupal.org/project/symfony_mailer/releases/1.4.0-beta2. We are currently on the 1.3.x branch version 1.3.1.

Notes from version 1.3.x: https://www.drupal.org/project/symfony_mailer/releases/1.3.2

Known issue: 1.3.x is not compatible with Drupal 10.1 due to [#3371042](https://www.drupal.org/project/symfony_mailer/issues/3371042): Drupal 10.1.0 new aggregation breaks InlineCssEmailAdjuster. This limitation affects all sites that style emails using CSS – other sites would be OK. Please upgrade to the 1.4 release to solve this problem