### PR TITLE
[GOVCMSD10-27] Correct the patch's module name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,7 +160,7 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-            "drupal/ds_devel": {
+            "drupal/ds": {
                 "Error using `ds_devel` - https://www.drupal.org/project/ds/issues/3338860": "https://www.drupal.org/files/issues/2023-04-04/3338860-5-d10-compatible_0.patch"
             },
             "drupal/login_security": {


### PR DESCRIPTION
Composer is not able to recognize the sub-module name. Therefore,  it won't apply the patch for a sub-module unless using the base module name instead.