### PR TITLE
[GOVCMSD10-265] Deprecate drupal/color module from GovCMS

### DIFF
--- a/modules/obsolete/color/color.info.yml
+++ b/modules/obsolete/color/color.info.yml
@@ -1,7 +1,0 @@
-name: Color
-type: module
-description: 'Allows users to change the color scheme of compatible themes. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Deprecate [Color backport](https://www.drupal.org/project/color) module from GovCMS.

- Remove https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/color stub module from the distribution codebase. 