### PR TITLE
[GOVCMSD10-273] Deprecate drupal/hal module from GovCMS

### DIFF
--- a/modules/obsolete/hal/hal.info.yml
+++ b/modules/obsolete/hal/hal.info.yml
@@ -1,7 +1,0 @@
-name: 'HAL'
-type: module
-description: 'Serializes entities using Hypertext Application Language. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Deprecate [Hypermedia Application Language (HAL)](https://www.drupal.org/project/hal) module from GovCMS.

- Remove https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/hal stub module from the distribution codebase.