### PR TITLE
[GOVCMSD10-274] Deprecate drupal/module_filter module from GovCMS

### DIFF
--- a/modules/obsolete/module_filter/module_filter.info.yml
+++ b/modules/obsolete/module_filter/module_filter.info.yml
@@ -1,7 +1,0 @@
-name: Module Filter
-type: module
-description: 'Filter the modules list. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Deprecate [Module Filter](https://www.drupal.org/project/module_filter) module from GovCMS.

- Remove https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/module_filter stub module from the distribution codebase.