### PR TITLE
[GOVCMSD10-265] Uninstall drupal/color, drupal/hal, drupal/module_filter, drupal/tracker modules in GovCMS

### DIFF
--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -76,3 +76,24 @@ function govcms_update_10002() {
     }
   }
 }
+
+/**
+ * Implements hook_update_N().
+ * Disables color, hal, module_filter, and tracker modules if the modules's lifecycle is obsolete.
+ */
+function govcms_update_10003() {
+  // List of modules to uninstall.
+  $modules_to_uninstall = ['color', 'hal', 'module_filter', 'tracker'];
+
+  // Get the module installer service.
+  $module_installer = \Drupal::service('module_installer');
+
+  // Uninstall each module in the array.
+  foreach ($modules_to_uninstall as $module) {
+    // Check if the module is installed before attempting to uninstall.
+    if (\Drupal::moduleHandler()->moduleExists($module)) {
+      // Uninstall the module using the module installer service.
+      $module_installer->uninstall([$module]);
+    }
+  }
+}

--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -87,11 +87,14 @@ function govcms_update_10003() {
 
   // Get the module installer service.
   $module_installer = \Drupal::service('module_installer');
+  $module_handler = \Drupal::service('module_handler');
 
   // Uninstall each module in the array.
   foreach ($modules_to_uninstall as $module) {
-    // Check if the module is installed before attempting to uninstall.
-    if (\Drupal::moduleHandler()->moduleExists($module)) {
+    // Check if the module is installed and marked as obsolete before attempting to uninstall.
+    $moduleInfo = \Drupal::service('extension.list.module')->getExtensionInfo($module);
+
+    if ($module_handler->moduleExists($module) && $moduleInfo && isset($moduleInfo['lifecycle']) && $moduleInfo['lifecycle'] === 'obsolete') {
       // Uninstall the module using the module installer service.
       $module_installer->uninstall([$module]);
     }


### PR DESCRIPTION
Deprecate [Color backport](https://www.drupal.org/project/color), [Hypermedia Application Language (HAL)](https://www.drupal.org/project/hal), [Module Filter](https://www.drupal.org/project/module_filter), [Activity Tracker](https://www.drupal.org/project/tracker) modules from GovCMS.

Step 1: Uninstall the modules in this release if their lifecycle is obsolete