### PR TITLE
[GOVCMSD10-265] Uninstall color, hal, module_filter, tracker modules in GovCMS

### DIFF
--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -76,3 +76,14 @@ function govcms_update_10002() {
     }
   }
 }
+
+function govcms_update_10003() {
+  // Get the Lifecycle service.
+  $lifecycle_service = \Drupal::service('govcms.modules.lifecycle');
+
+  // List of modules to uninstall.
+  $modules_to_uninstall = ['color', 'hal', 'module_filter', 'tracker'];
+
+  // Call the service method to uninstall specified modules marked as 'obsolete'.
+  $lifecycle_service->uninstallObsoleteModules($modules_to_uninstall);
+}

--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -77,6 +77,10 @@ function govcms_update_10002() {
   }
 }
 
+/**
+ * Implements hook_update_N().
+ * Disables color, hal, module_filter, and tracker modules if the modules's lifecycle is obsolete.
+ */
 function govcms_update_10003() {
   // Get the Lifecycle service.
   $lifecycle_service = \Drupal::service('govcms.modules.lifecycle');

--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -79,7 +79,7 @@ function govcms_update_10002() {
 
 /**
  * Implements hook_update_N().
- * Disables color, hal, module_filter, and tracker modules if the modules's lifecycle is obsolete.
+ * Disables specified modules if marked as 'obsolete'.
  */
 function govcms_update_10003() {
   // Get the Lifecycle service.

--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\govcms\Modules;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
 /**
  * Service description.
  */
@@ -17,6 +19,9 @@ class Lifecycle {
     'config_filter',
     'panelizer',
   ];
+
+  // Constant for 'obsolete' lifecycle status.
+  const MODULE_LIFECYCLE_OBSOLETE = 'obsolete';
 
   /**
    * Constructs a new service.
@@ -38,4 +43,26 @@ class Lifecycle {
     $info['lifecycle_link'] = 'https://github.com/GovCMS/GovCMS';
   }
 
+  /**
+   * Uninstalls modules marked as obsolete.
+   *
+   * @param array $modules
+   *   The modules to uninstall.
+   */
+  public function uninstallObsoleteModules(array $modules): void {
+    // Get the module installer service.
+    $module_installer = \Drupal::service('module_installer');
+    $module_handler = \Drupal::service('module_handler');
+
+    foreach ($modules as $module) {
+      // Check if the module is installed and marked as obsolete before attempting to uninstall.
+      if ($module_handler->moduleExists($module)) {
+        $moduleInfo = \Drupal::service('extension.list.module')->getExtensionInfo($module);
+
+        if ($moduleInfo && isset($moduleInfo['lifecycle']) && $moduleInfo['lifecycle'] === self::MODULE_LIFECYCLE_OBSOLETE) {
+          $module_installer->uninstall([$module]);
+        }
+      }
+    }
+  }
 }

--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\govcms\Modules;
 
+use Drupal\Core\Extension\ExtensionLifecycle;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
@@ -19,9 +20,6 @@ class Lifecycle {
     'config_filter',
     'panelizer',
   ];
-
-  // Constant for 'obsolete' lifecycle status.
-  const MODULE_LIFECYCLE_OBSOLETE = 'obsolete';
 
   /**
    * Constructs a new service.
@@ -59,7 +57,7 @@ class Lifecycle {
       if ($module_handler->moduleExists($module)) {
         $moduleInfo = \Drupal::service('extension.list.module')->getExtensionInfo($module);
 
-        if ($moduleInfo && isset($moduleInfo['lifecycle']) && $moduleInfo['lifecycle'] === self::MODULE_LIFECYCLE_OBSOLETE) {
+        if ($moduleInfo && isset($moduleInfo['lifecycle']) && $moduleInfo['lifecycle'] === ExtensionLifecycle::OBSOLETE) {
           $module_installer->uninstall([$module]);
         }
       }


### PR DESCRIPTION
Deprecate [Color backport](https://www.drupal.org/project/color), [Hypermedia Application Language (HAL)](https://www.drupal.org/project/hal), [Module Filter](https://www.drupal.org/project/module_filter), [Activity Tracker](https://www.drupal.org/project/tracker) modules from GovCMS.

Step 1: Uninstall the modules in this release if their lifecycle is obsolete