### PR TITLE
[GOVCMSD10-400] Remove color, hal, module_filter, tracker modules from GovCMS distribution

### DIFF
--- a/modules/obsolete/color/color.info.yml
+++ b/modules/obsolete/color/color.info.yml
@@ -1,7 +1,0 @@
-name: Color
-type: module
-description: 'Allows users to change the color scheme of compatible themes. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/hal/hal.info.yml
+++ b/modules/obsolete/hal/hal.info.yml
@@ -1,7 +1,0 @@
-name: 'HAL'
-type: module
-description: 'Serializes entities using Hypertext Application Language. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/module_filter/module_filter.info.yml
+++ b/modules/obsolete/module_filter/module_filter.info.yml
@@ -1,7 +1,0 @@
-name: Module Filter
-type: module
-description: 'Filter the modules list. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/tracker/tracker.info.yml
+++ b/modules/obsolete/tracker/tracker.info.yml
@@ -1,7 +1,0 @@
-name: Activity Tracker
-type: module
-description: 'Enables tracking of recent content for users. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Deprecate [Color backport](https://www.drupal.org/project/color), [Hypermedia Application Language (HAL)](https://www.drupal.org/project/hal), [Module Filter](https://www.drupal.org/project/module_filter), [Activity Tracker](https://www.drupal.org/project/tracker) modules from GovCMS.

Step 1: Uninstall color, hal, module_filter, tracker modules if their lifecycle is 'obsolete'. (This step was done in 3.7.0 release).

**Step 2: Remove the stub modules from the distribution codebase https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete in this release.**