### PR TITLE
[GOVCMSD10-267] Deprecate specific  modules from GovCMS

### DIFF
--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -91,3 +91,18 @@ function govcms_update_10003() {
   // Call the service method to uninstall specified modules marked as 'obsolete'.
   $lifecycle_service->uninstallObsoleteModules($modules_to_uninstall);
 }
+
+/**
+ * Implements hook_update_N().
+ * Disables specified modules if marked as 'obsolete'.
+ */
+function govcms_update_10004() {
+  // Get the Lifecycle service.
+  $lifecycle_service = \Drupal::service('govcms.modules.lifecycle');
+
+  // List of modules to uninstall.
+  $modules_to_uninstall = ['features', 'features_ui', 'govcms_media', 'govcms_news_and_media', 'govcms_search', 'govcms_standard_page'];
+
+  // Call the service method to uninstall specified modules marked as 'obsolete'.
+  $lifecycle_service->uninstallObsoleteModules($modules_to_uninstall);
+}

--- a/modules/obsolete/govcms8_foundations/govcms8_calendar_item.info.yml
+++ b/modules/obsolete/govcms8_foundations/govcms8_calendar_item.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS8 Calendar Item'
-type: module
-description: 'Provides custom calendar item formatter and DS field for UI-Kit. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms8_foundations/govcms8_foundations.info.yml
+++ b/modules/obsolete/govcms8_foundations/govcms8_foundations.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS8 Foundations'
-type: module
-description: 'GovCMS8 Foundations Module. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms8_foundations/govcms8_layouts.info.yml
+++ b/modules/obsolete/govcms8_foundations/govcms8_layouts.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS8 Layouts'
-type: module
-description: 'Provides layouts for the GovCMS8 distribution. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms8_foundations/govcms8_modifiers.info.yml
+++ b/modules/obsolete/govcms8_foundations/govcms8_modifiers.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS8 Modifiers'
-type: module
-description: 'Provides modifiers for the GovCMS8 distribution. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -19,6 +19,7 @@ class Lifecycle {
   const OBSOLETE_MODULES = [
     'config_filter',
     'panelizer',
+    'forum'
   ];
 
   /**

--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -18,8 +18,8 @@ class Lifecycle {
   // Obsolete modules.
   const OBSOLETE_MODULES = [
     'config_filter',
+    'forum',
     'panelizer',
-    'forum'
   ];
 
   /**


### PR DESCRIPTION
**Deprecate the following modules from GovCMS:**
* features - uninstall module
* features_ui - uninstall module
* forum - mark as 'obsolete'
* govcms8_foundations - mark as 'obsolete' in lagoon and remove module from GovCMS codebase
    * govcms8_calendar_item - mark as 'obsolete' in lagoon and remove module from GovCMS codebase
    * govcms8_layouts - mark as 'obsolete' in lagoon and remove module from GovCMS codebase
    * govcms8_modifiers - mark as 'obsolete' in lagoon and remove module from GovCMS codebase
* govcms_media - uninstall module
* govcms_news_and_media - uninstall module
* govcms_search - uninstall module
* govcms_standard_page - uninstall module

