### PR TITLE
[GOVCMSD10-444] Mark drupal/swiftmailer module as 'obsolete'

### DIFF
--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -20,6 +20,7 @@ class Lifecycle {
     'config_filter',
     'forum',
     'panelizer',
+    'swiftmailer',
   ];
 
   /**

--- a/src/Modules/Lifecycle.php
+++ b/src/Modules/Lifecycle.php
@@ -11,9 +11,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 class Lifecycle {
 
   // Deprecated modules.
-  const DEPRECATED_MODULES = [
-    'swiftmailer',
-  ];
+  const DEPRECATED_MODULES = [];
 
   // Obsolete modules.
   const OBSOLETE_MODULES = [


### PR DESCRIPTION
Security Advisory - https://www.drupal.org/sa-contrib-2024-006 
Project: Swift Mailer
Date: 2024-January-24
Security risk: [Moderately critical 12∕25 AC:Basic/A:None/CI:Some/II:None/E:Theoretical/TD:Default](https://www.drupal.org/security-team/risk-levels)
Vulnerability: Access Bypass
Affected versions: 
 
Description: 

The Drupal Swift Mailer module extends the basic e-mail sending functionality provided by Drupal by delegating all e-mail handling to the Swift Mailer library. This enables your site to take advantage of the many features which the Swift Mailer library provides.

The module could allow an attacker to gain widespread access to a Drupal site. This vulnerability is mitigated by the fact that an attacker must have a means to trigger sending an email with a body that they can control, which would requires either another contributed module or custom integration.

Solution: 

Uninstall this module immediately. The swiftmailer library has been unsupported for a year, and this module is now also unsupported.

**Step 1: Mark swiftmailer module as 'obsolete' in GovCMS distribution.**