### PR TITLE
[GOVCMSD10-425] Update drupal/entity_hierarchy module from 3.3.9 to 3.3.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "drupal/entity_browser": "2.9.0",
         "drupal/entity_class_formatter": "2.0.0",
         "drupal/entity_embed": "1.5",
-        "drupal/entity_hierarchy": "3.3.9",
+        "drupal/entity_hierarchy": "3.3.10",
         "drupal/entity_reference_display": "2.0.0",
         "drupal/entity_reference_revisions": "1.11.0",
         "drupal/environment_indicator": "4.0.17",


### PR DESCRIPTION
**entity_hierarchy 3.3.10**
https://www.drupal.org/project/entity_hierarchy/releases/3.3.10

**Release notes**

[#3356967: Route permissions have trouble with context](https://www.drupal.org/project/entity_hierarchy/issues/3356967)
[#3400747: gitlab ci and coding standards](https://www.drupal.org/project/entity_hierarchy/issues/3400747)
[#3402970: Child hierarchy notice references 'Entity Test' instead of entity type](https://www.drupal.org/project/entity_hierarchy/issues/3402970)
[#3403718: Drupal\Core\Database\Connection::tablePrefix() is deprecated in drupal:10.1.0 and is removed from drupal:11.0.0](https://www.drupal.org/project/entity_hierarchy/issues/3403718)