### PR TITLE
[GOVCMSD10-442] Uninstall drupal/swiftmailer module from GovCMS - Step 2

### DIFF
--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -121,3 +121,18 @@ function govcms_update_10005() {
     \Drupal::service('module_installer')->install(['symfony_mailer']);
   }
 }
+
+/**
+ * Implements hook_update_N().
+ * Disables swiftmailer module if marked as 'obsolete'.
+ */
+function govcms_update_10006() {
+  // Get the Lifecycle service.
+  $lifecycle_service = \Drupal::service('govcms.modules.lifecycle');
+
+  // List of modules to uninstall.
+  $modules_to_uninstall = ['swiftmailer'];
+
+  // Call the service method to uninstall specified modules marked as 'obsolete'.
+  $lifecycle_service->uninstallObsoleteModules($modules_to_uninstall);
+}

--- a/includes/govcms.update.inc
+++ b/includes/govcms.update.inc
@@ -126,7 +126,7 @@ function govcms_update_10005() {
  * Implements hook_update_N().
  * Disables swiftmailer module if marked as 'obsolete'.
  */
-function govcms_update_10006() {
+function govcms_update_10005() {
   // Get the Lifecycle service.
   $lifecycle_service = \Drupal::service('govcms.modules.lifecycle');
 


### PR DESCRIPTION
**Description**

Deprecate swiftmailer module from GovCMS:

The SaaS client can start switching manually with help from the helpdesk.

We put this module into obsolete process of GovCMS module lifecycle

1. Set it to obsolete
2. **Uninstall swiftmailer module** and enable the symfony_mailer module if it's enabled. Default lagoon mail settings will be applied, and the helpdesk can assist with any questions or issues.
3. Delete swiftmailer from the distribution and other projects' codebase.