### PR TITLE
[GOVCMSD10-536] Remove drupal/swiftmailer module from GovCMS - Step 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,17 +112,14 @@
         "drupal/shield": "1.7.0",
         "drupal/simple_oauth": "5.2.5",
         "drupal/simple_sitemap": "4.1.8",
-        "drupal/swiftmailer": "2.4.0",
         "drupal/symfony_mailer": "1.4.1",
         "drupal/tfa": "1.5.0",
         "drupal/token": "1.13.0",
         "drupal/twig_tweak": "3.2.1",
         "drupal/username_enumeration_prevention": "1.3.0",
         "drupal/webform": "6.2.2",
-        "egulias/email-validator": "4.0.2",
         "govcms-assets/chosen": "2.2.1",
         "oomphinc/composer-installers-extender": "^2.0",
-        "swiftmailer/swiftmailer": "6.3.0",
         "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
Deprecate swiftmailer module from GovCMS:

1. The SaaS client can start switching manually with help from the helpdesk.

2. We put this module into obsolete process of GovCMS module lifecycle
a. Set it to obsolete
b. Uninstall swiftmailer module and enable the symfony_mailer module if it's enabled. Default lagoon mail settings will be applied, and the helpdesk can assist with any questions or issues.
c. Delete swiftmailer from the distribution and other projects' codebase.