### PR TITLE
[GOVCMSD10-542] Add php-http/discovery to the composer allow-plugins n GovCMS Distro

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "oomphinc/composer-installers-extender": true,
             "drupal/core-vendor-hardening": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         },
         "bin-dir": "bin/",
         "sort-packages": true,


### PR DESCRIPTION
php-http/discovery plugin is needed as part of the update to core 10.2