### PR TITLE
[GOVCMSD10-531] Remove features, govcms_media, govcms_news_and_media,govcms_search, govcms_standard_page modules from GovCMS codebase - Step 2

### DIFF
--- a/modules/obsolete/features/features.info.yml
+++ b/modules/obsolete/features/features.info.yml
@@ -1,7 +1,0 @@
-name: Features
-type: module
-description: 'Enables administrators to package configuration into modules. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/features/features_ui.info.yml
+++ b/modules/obsolete/features/features_ui.info.yml
@@ -1,7 +1,0 @@
-name: Features UI
-type: module
-description: 'Provides the user interface for Features. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms_media/govcms_media.info.yml
+++ b/modules/obsolete/govcms_media/govcms_media.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS Media'
-type: module
-description: 'Provide media management functionality. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms_news_and_media/govcms_news_and_media.info.yml
+++ b/modules/obsolete/govcms_news_and_media/govcms_news_and_media.info.yml
@@ -1,7 +1,0 @@
-name: 'News and Media'
-type: module
-description: 'Provides News and Media content type and related configuration. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms_search/govcms_search.info.yml
+++ b/modules/obsolete/govcms_search/govcms_search.info.yml
@@ -1,7 +1,0 @@
-name: 'GovCMS Search'
-type: module
-description: 'Provide default search functions. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/obsolete/govcms_standard_page/govcms_standard_page.info.yml
+++ b/modules/obsolete/govcms_standard_page/govcms_standard_page.info.yml
@@ -1,7 +1,0 @@
-name: 'Standard page'
-type: module
-description: 'Provides Standard page content type and related configuration. [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Deprecate features, fautures_ui, govcms_media, govcms_news_and_media, govcms_search, govcms_standard_page modules from GovCMS.

**Step 1:** Uninstall features, fautures_ui, govcms_media, govcms_news_and_media, govcms_search, govcms_standard_page modules if their lifecycle is 'obsolete'. (This step was done in 3.8.0 release - [GOVCMSD10-267] Deprecate specified  modules from GovCMS by Tara-Wij · Pull Request #994 · govCMS/GovCMS ).

**Step 2: Remove the stub modules from the distribution codebase https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete in this release (3.10.0).**