### PR TITLE
Revert "[GOVCMSD10-447] Update drupal/scheduled_transitions module from 2.3.0 to 2.4.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
         "drupal/rest_menu_items": "3.0.3",
         "drupal/robotstxt": "1.5.0",
         "drupal/role_delegation": "1.2.0",
-        "drupal/scheduled_transitions": "2.4.1",
+        "drupal/scheduled_transitions": "2.3.0",
         "drupal/search_api": "1.31.0",
         "drupal/search_api_attachments": "9.0.2",
         "drupal/search_api_solr": "4.3.1",


### PR DESCRIPTION
Reverts govCMS/GovCMS#1003