### PR TITLE
[GOVCMSD10-793] Update drupal/core-dev from 10.1 to 10.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.1",
+        "drupal/core-dev": "^10.2",
         "drush/drush": "~12"
     },
     "config": {


### PR DESCRIPTION
This update is necessary to ensure compatibility and take advantage of the latest features and fixes provided by the Drupal core. 