### PR TITLE
Release 3.12.0 (#1098)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
         "drupal/consumers": "1.17.0",
         "drupal/contact_storage": "1.3.0",
         "drupal/context": "5.0.0-rc1",
-        "drupal/core-composer-scaffold": "10.1.8",
-        "drupal/core-recommended": "10.1.8",
+        "drupal/core-composer-scaffold": "10.2.6",
+        "drupal/core-recommended": "10.2.6",
         "drupal/crop": "2.3.0",
         "drupal/ctools": "3.14.0",
         "drupal/devel": "5.1.2",
@@ -112,7 +112,7 @@
         "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.1",
+        "drupal/core-dev": "^10.2",
         "drush/drush": "~12"
     },
     "config": {

--- a/config/install/editor.editor.rich_text.yml
+++ b/config/install/editor.editor.rich_text.yml
@@ -57,8 +57,10 @@ settings:
         - '<ol type>'
         - '<img data-entity-type data-entity-uuid>'
     ckeditor5_list:
-      reversed: false
-      startIndex: true
+      properties:
+        reversed: false
+        startIndex: true
+      multiBlock: true
     ckeditor5_alignment:
       enabled_alignments:
         - left

--- a/govcms.info.yml
+++ b/govcms.info.yml
@@ -3,7 +3,7 @@ type: profile
 description: 'A GovCMS Drupal Distribution for government and the public sector in Australia.'
 core_version_requirement: ^10
 project: 'govcms'
-version: '3.11.0'
+version: '3.12.0'
 
 distribution:
   name: GovCMS

--- a/includes/govcms.alter.inc
+++ b/includes/govcms.alter.inc
@@ -84,3 +84,14 @@ function govcms_field_widget_complete_form_alter(array &$field_widget_complete_f
     'field_widget_complete_' . $context['widget']->getPluginId() . '_form',
   ], $field_widget_complete_form, $form_state, $context);
 }
+
+/**
+ * Implements hook_config_schema_info_alter().
+ */
+function govcms_config_schema_info_alter(&$definitions)
+{
+    if (isset($definitions['ckeditor5.plugin.ckeditor5_sourceEditing']))
+    {
+        unset($definitions['ckeditor5.plugin.ckeditor5_sourceEditing']['mapping']['allowed_tags']['sequence']['constraints']['SourceEditingRedundantTags']);
+    }
+}


### PR DESCRIPTION
* Update drupal/core-composer-scaffold requirement from 10.1.8 to 10.2.5

Updates the requirements on [drupal/core-composer-scaffold](https://github.com/drupal/core-composer-scaffold) to permit the latest version.
- [Commits](https://github.com/drupal/core-composer-scaffold/compare/10.1.8...10.2.5)

---
updated-dependencies:
- dependency-name: drupal/core-composer-scaffold dependency-type: direct:production ...



* Update drupal/core-recommended requirement from 10.1.8 to 10.2.5

Updates the requirements on [drupal/core-recommended](https://github.com/drupal/core-recommended) to permit the latest version.
- [Commits](https://github.com/drupal/core-recommended/compare/10.1.8...10.2.5)

---
updated-dependencies:
- dependency-name: drupal/core-recommended dependency-type: direct:production ...



* Update composer.json

* Update editor.editor.rich_text.yml

* Update drupal/core-recommended requirement from 10.2.5 to 10.2.6

Updates the requirements on [drupal/core-recommended](https://github.com/drupal/core-recommended) to permit the latest version.
- [Commits](https://github.com/drupal/core-recommended/compare/10.2.5...10.2.6)

---
updated-dependencies:
- dependency-name: drupal/core-recommended dependency-type: direct:production ...



* Update drupal/core-composer-scaffold requirement from 10.2.5 to 10.2.6

Updates the requirements on [drupal/core-composer-scaffold](https://github.com/drupal/core-composer-scaffold) to permit the latest version.
- [Commits](https://github.com/drupal/core-composer-scaffold/compare/10.2.5...10.2.6)

---
updated-dependencies:
- dependency-name: drupal/core-composer-scaffold dependency-type: direct:production ...



* add hook to remove plugin validation

* change module to govcms

* [GOVCMS-10426] Prepare GovCMS Distro release 3.12.0

---------