### PR TITLE
[GOVCMSD10-832] Update drupal/layout_builder_restrictions module from 2.19.0 to 2.20.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "drupal/honeypot": "2.1.3",
         "drupal/key": "1.17.0",
         "drupal/layout_builder_modal": "1.2.0",
-        "drupal/layout_builder_restrictions": "2.19.0",
+        "drupal/layout_builder_restrictions": "2.20.0",
         "drupal/linked_field": "1.5.0",
         "drupal/linkit": "6.1.4",
         "drupal/login_security": "2.0.1",


### PR DESCRIPTION
**layout_builder_restrictions 8.x-2.20**
[layout_builder_restrictions 8.x-2.20](https://www.drupal.org/project/layout_builder_restrictions/releases/8.x-2.20) 

**Release notes**

This is the final planned release of the 8.x-2.x branch, to be followed by a semver-valid 3.x branch that will include Drupal 11 compatibility.

Contributors (1)
[mark_fullmer](https://www.drupal.org/u/mark_fullmer)

**Changelog**
Issues: 2 issues resolved.

Changes since [8.x-2.19](https://www.drupal.org/project/layout_builder_restrictions/releases/8.x-2.19):

**Misc**
Add Gitlab CI for automated testing

Update .gitlab-ci.yml

Update .gitlab-ci.yml file to test next major version of Drupal

**Task**
[#3411038](https://www.drupal.org/i/3411038): The definition for the 'core.entity_view_display.*.*.*.third_party_settings.layout_builder_restrictions' sequence declares the type of its items in a way that is deprecated in drupal:8.0.0 and is removed from drupal:11.0.0

[#3447701](https://www.drupal.org/i/3447701) by mark_fullmer: Tests fail on Drupal 10.2.x