### PR TITLE
[GOVCMSD10-840] Update TFA module version 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "drupal/simple_sitemap": "4.1.8",
         "drupal/symfony_mailer": "1.4.1",
         "drupal/token": "1.14.0",
-        "drupal/tfa": "1.5.0",
+        "drupal/tfa": "1.7.0",
         "drupal/twig_tweak": "3.3.0",
         "drupal/username_enumeration_prevention": "1.3.0",
         "drupal/webform": "6.2.2",

--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -110,7 +110,7 @@ function govcms_security_form_tfa_settings_form_alter(&$form, FormStateInterface
     $form['tfa_required_roles']['#access'] = FALSE;
   }
   // Limit the max validation skip to 10.
-  $form['validation_skip']['#max'] = 10;
+  $form['users_without_tfa']['validation_skip']['#max'] = 10;
 }
 
 /**


### PR DESCRIPTION
Updates the tfa_settings_form_alter() hook to work with TFA version 1.7.0, which introduced changes to the form schema.