### PR TITLE
[GOVCMSD10-922] Remove patch for login_security module from the GovCMS distribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,9 +153,6 @@
         "enable-patching": true,
         "composer-exit-on-patch-failure": true,
         "patches": {
-            "drupal/login_security": {
-                "Correctly detect invalid username/password or blocked account login errors - https://www.drupal.org/project/login_security/issues/3292974": "https://www.drupal.org/files/issues/2023-02-14/login_security-3292974-21.patch"
-            },
             "drupal/tfa": {
                 "Create Email one-time-code Validation Plugin & related Setup Plugin - https://www.drupal.org/project/tfa/issues/2930541": "https://www.drupal.org/files/issues/2023-07-19/tfa-2930541-81.patch"
             }


### PR DESCRIPTION
The issue https://www.drupal.org/project/login_security/issues/3292974  for the login_security module has been fixed in Login Security version 2.0.1. Therefore, the patch should be removed from the GovCMS distribution.