### PR TITLE
[GOVCMSD10-437] Upgrade to PHP 8.3

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM drupal:10-php8.1 as builder
+FROM drupal:10-php8.3 as builder
 
 # Set timezone to Australia/Sydney by default
 RUN ln -sf /usr/share/zoneinfo/Australia/Sydney /etc/localtime

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -14,7 +14,7 @@ services:
         - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
 
   app:
-    image: tugboatqa/php:8.1-apache
+    image: tugboatqa/php:8.3-apache
     # Set this as the default service. This does a few things
     #   1. Clones the git repository into the service container
     #   2. Exposes port 80 to the Tugboat HTTP proxy

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://govcmschat.slack.com/archives/C01BD9B3V5W
 To get started with GovCMS, you need to have the following prerequisites:
 
 - A web server like Apache or Nginx
-- PHP version 8.1 or above
+- PHP version 8.3 or above
 - MySQL or PostgresSQL database
 
 More documents can be found in:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.1.0",
+        "php": "^8.3.0",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "govcms-assets/dropzone": "5.7.2",


### PR DESCRIPTION
PHP 8.3 is out, and Drupal 10.2+ has support for it.
https://www.php.net/releases/8.3/en.php