### PR TITLE
[GOVCMSD10-716] Remove block_place module stubs from GovCMS distribution

### DIFF
--- a/modules/obsolete/block_place/block_place.info.yml
+++ b/modules/obsolete/block_place/block_place.info.yml
@@ -1,7 +1,0 @@
-name: Place Blocks
-type: module
-description: 'Allow administrators to place blocks from any Drupal page [obsolete]'
-package: GovCMS [obsolete]
-core_version_requirement: ^9 || ^10
-lifecycle: obsolete
-lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Remove block_place module stubs from GovCMS distribution.
The block_place module was uninstalled from the GovCMS 3.15.0 release. 