### PR TITLE
[GOVCMSD10-713] Update drupal/devel module from 5.1.2 to 5.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "drupal/core-recommended": "10.3.6",
         "drupal/crop": "2.4.0",
         "drupal/ctools": "4.1.0",
-        "drupal/devel": "5.1.2",
+        "drupal/devel": "5.3.1",
         "drupal/diff": "1.8.0",
         "drupal/dropzonejs": "2.11.0",
         "drupal/ds": "3.24.0",


### PR DESCRIPTION
devel 5.3.1
[devel 5.3.1](https://www.drupal.org/project/devel/releases/5.3.1) 

Release notes

Drupal 11 compat