### PR TITLE
Revert "[GOVCMSD10-1134] Update drupal/migrate_tools module from 6.0.4 to 6.0.5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "drupal/migrate_file": "2.1.2",
         "drupal/migrate_plus": "6.0.4",
         "drupal/migrate_source_csv": "3.6.0",
-        "drupal/migrate_tools": "6.0.5",
+        "drupal/migrate_tools": "6.0.4",
         "drupal/minisite": "2.3.0",
         "drupal/modifiers": "1.6.0",
         "drupal/module_permissions": "3.2.0",


### PR DESCRIPTION
Reverts govCMS/GovCMS#1285