### PR TITLE
[GOVCMSD11-212] Update drupal/twig_tweak module from 3.4.0 to 3.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "drupal/symfony_mailer": "1.5.0",
         "drupal/token": "1.15.0",
         "drupal/tfa": "1.10.0",
-        "drupal/twig_tweak": "3.4.0",
+        "drupal/twig_tweak": "3.4.1",
         "drupal/username_enumeration_prevention": "1.4.0",
         "drupal/webform": "6.3.0-beta2",
         "govcms-assets/chosen": "2.2.1",


### PR DESCRIPTION
twig_tweak 3.4.1
[twig_tweak 3.4.1](https://www.drupal.org/project/twig_tweak/releases/3.4.1) 

 

Release notes

[#3500245: Nullable types must be explicit](https://www.drupal.org/project/twig_tweak/issues/3500245)
[#3472506: Wrong constraint on project page](https://www.drupal.org/project/twig_tweak/issues/3472506)