### PR TITLE
[GOVCMSD11-211] Update drupal/rest_menu_items module from 3.0.4 to 3.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
         "drupal/recaptcha": "3.4.0",
         "drupal/recaptcha_v3": "2.0.4",
         "drupal/redirect": "1.11.0",
-        "drupal/rest_menu_items": "3.0.4",
+        "drupal/rest_menu_items": "3.0.5",
         "drupal/robotstxt": "1.6.0",
         "drupal/role_delegation": "1.3.0",
         "drupal/search_api": "1.38.0",


### PR DESCRIPTION
rest_menu_items 3.0.5
[rest_menu_items 3.0.5](https://www.drupal.org/project/rest_menu_items/releases/3.0.5) 

 

Release notes

Add a summary here

Contributors (2)
[batigolix](https://www.drupal.org/u/batigolix), [petar_basic](https://www.drupal.org/u/petar_basic)

Changelog
Issues: 1 issues resolved.

Changes since [3.0.4](https://www.drupal.org/project/rest_menu_items/releases/3.0.4) ([compare](https://git.drupalcode.org/project/rest_menu_items/-/compare/3.0.4...3.0.5)):

Bug
[#3479928](https://www.drupal.org/i/3479928) by petar_basic, batigolix: Warning Undefined array key "entity_id" in checkContentFields