### PR TITLE
[GOVCMSD11-213] Update drupal/consultation-consultation module from 1.0.4 to 1.1.0 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,6 @@
         "drush/drush": "~13"
     },
     "replace": {
-        "drupal/consultation-consultation": "*",
         "drupal/google_analytics": "*",
         "drupal/linked_field": "*",
         "drupal/media_vimeo_domain_privacy": "*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/config_perms": "2.3.0",
         "drupal/config_split": "2.0.2",
         "drupal/config_update": "2.0.0-alpha4",
-        "drupal/consultation-consultation": "1.0.4",
+        "drupal/consultation-consultation": "1.1.0",
         "drupal/consumers": "1.19.0",
         "drupal/contact_storage": "1.4.0",
         "drupal/context": "5.0.0-rc2",


### PR DESCRIPTION
consultation 1.1.0
[consultation 1.1.0](https://www.drupal.org/project/consultation/releases/1.1.0) 

 

Release notes

Drupal 11 release and bug fixes

Issue #3419657 by mingsong, cb_govcms, dineshkumarbollu, tarawij, Kristen Pol: changes for deprecated issue

Issue #3423257 by Kristen Pol, Toby Wild: Remove unused consultation test

Issue #3423267 by Kristen Pol: Add missing consultation.settings schema file

Issue #3423266 by Kristen Pol: Add missing views dependency in consultation.info.yml

Issue #3422536 by Anjali Mehta, Kristen Pol: Add Gitlab CI

Issue #3419938 by Toby Wild, Kristen Pol: Not compatible with Resend functionality in Webform

Issue #3323306 by kuntal_d, Kristen Pol: Text format isn't preselected for some text areas

Issue #3367773 by larowlan: Config from needlessly saves configuration multiple times

Issue #3420729 by Kristen Pol, Toby Wild: Module installation doesn't include required modules

Issue #3422475 by Kristen Pol, Toby Wild: Consultation spelled incorrectly in a few places

Issue #3422478 by Kristen Pol: Consultation module does not cleanly uninstall