### PR TITLE
[GOVCMSD11-453] Add drupal/search_api_autocomplete module to GovCMS D11 Distribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "drupal/scheduled_transitions": "2.8.3",
         "drupal/search_api": "1.39.0",
         "drupal/search_api_attachments": "10.0.5",
+        "drupal/search_api_autocomplete": "1.10.0",
         "drupal/search_api_solr": "4.3.10",
         "drupal/search_api_spellcheck": "4.0.1",
         "drupal/seckit": "2.0.3",


### PR DESCRIPTION
Adding Search API Autocomplete module [8.x-1.10](https://www.drupal.org/project/search_api_autocomplete/releases/8.x-1.10) to distro.