### PR TITLE
Allowed installation of SimpleSAMLphp modules.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
             "drupal/core-vendor-hardening": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
-            "simplesamlphp/composer-module-installer": false,
+            "simplesamlphp/composer-module-installer": true,
             "simplesamlphp/composer-xmlprovider-installer": false,
             "tbachert/spi": true
         },


### PR DESCRIPTION
# Issue
- The current `composer.json` sets:
  ```json
  "simplesamlphp/composer-module-installer": false
  ```
  This disables SimpleSAMLphp’s Composer Module Installer — the plugin responsible for automatically installing and registering additional SimpleSAMLphp modules.

- As a result, modules such as `simplesamlphp/simplesamlphp-assets-base` are **not automatically detected or enabled** by SimpleSAMLphp.

- When using **HTTP-POST bindings**, SAML authentication data is transmitted via an intermediary form page. Without the `simplesamlphp-assets-base` module, this form lacks the **auto-submit** functionality, causing users to get stuck on that intermediary page until they manually submit it.

- Keeping `"simplesamlphp/composer-module-installer": true` is the recommended approach, ensuring that all SimpleSAMLphp modules (e.g. assets, themes, or authentication handlers) are automatically registered during installation.

# Proposed Solution
- Update `composer.json` to:
  ```json
  "simplesamlphp/composer-module-installer": true
  ```
- This change restores automatic module installation and registration, allowing modules like `simplesamlphp/simplesamlphp-assets-base` to function as intended.  
- It resolves the HTTP-POST binding issue and improves maintainability by ensuring all required modules are consistently managed by Composer.
