### PR TITLE
Update drupal/book requirement from 3.0.0 to 2.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal/admin_toolbar": "3.6.2",
         "drupal/anchor_link": "3.0.4",
         "drupal/bigmenu": "2.1.0",
-        "drupal/book": "3.0.0",
+        "drupal/book": "2.0.4",
         "drupal/captcha": "2.0.10",
         "drupal/chosen": "5.0.3",
         "drupal/components": "3.2.0",


### PR DESCRIPTION
Downgrading book module to 2.0.4 as there are potential breaks for existing book content types during migration with book module 3.0.0