### PR TITLE
[GOVCMSD11-323] Set up Dependabot to manage updates in the D11 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,18 @@ version: 2
 updates:
 - package-ecosystem: composer
   directory: "/"
+  ignore:
+    - dependency-name: "drupal/core*"
+      update-types: ["version-update:semver-major"]
+  groups:
+    drupal-core:
+      patterns:
+        - "drupal/core*"
   schedule:
     interval: daily
     time: "06:00"
     timezone: "Australia/Sydney"
   open-pull-requests-limit: 50
-  target-branch: 3.x-develop
+  target-branch: 4.x-develop
   reviewers:
   - pandaskii


### PR DESCRIPTION
Updated target branch for Dependabot and added ignore rules for major version updates of drupal/core.